### PR TITLE
Explicitly set default value of range.collapse to false.

### DIFF
--- a/src/edit/selection.js
+++ b/src/edit/selection.js
@@ -60,7 +60,7 @@ export class Selection {
 
     if (sel.extend) {
       range.setEnd(anchor.node, anchor.offset)
-      range.collapse()
+      range.collapse(false)
     } else {
       if (this.range.anchor.cmp(this.range.head) > 0) { let tmp = anchor; anchor = head; head = tmp }
       range.setEnd(head.node, head.offset)


### PR DESCRIPTION
Microsoft Edge defaults to true (beginning) instead of the required end.