### PR TITLE
Include babel in install documentation

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -32,6 +32,10 @@ To build a script, make sure you've installed the ProseMirror package:
     cd node_modules/prosemirror
     npm run dist
 
+If you don't already have `babel` installed globally or in your project, also install `babel` as it is used to build ProseMirror:
+
+	npm install --save babel
+
 (FIXME: this will become simply `npm install prosemirror` when an NPM
 package is available)
 


### PR DESCRIPTION
This was my solution for #26, which I ran into because Travis was failing my project (that includes ProseMirror). I added `babel` as a dependency of my project and then Travis was happy and the project built successfully.

This is *just* a documentation addition.