### PR TITLE
Fix removeInputRules typo

### DIFF
--- a/src/inputrules/inputrules.js
+++ b/src/inputrules/inputrules.js
@@ -6,7 +6,7 @@ export function addInputRules(pm, rules) {
   pm.mod.interpretInput.addRules(rules)
 }
 
-export function removeInputRule(pm, rules) {
+export function removeInputRules(pm, rules) {
   let ii = pm.mod.interpretInput
   if (!ii) return
   ii.removeRules(rules)


### PR DESCRIPTION
I found this while trying to change the `autoInput` option on the fly: https://github.com/ProseMirror/prosemirror/blob/153adc36d57244d7c0553d3659528850368f7e91/src/inputrules/autoinput.js#L7