### PR TITLE
fix text composition update error

### DIFF
--- a/src/edit/input.js
+++ b/src/edit/input.js
@@ -146,14 +146,14 @@ handlers.compositionstart = (pm, e) => {
 }
 
 handlers.compositionupdate = (pm, e) => {
-  let info = pm.input.composing
-  if (info && info.data != e.data) {
-    info.data = e.data
-    pm.input.updatingComposition = true
-    inputText(pm, info.range, info.data)
-    pm.input.updatingComposition = false
-    info.range = new Range(info.range.from, info.range.from.shift(info.data.length))
-  }
+  // let info = pm.input.composing
+  // if (info && info.data != e.data) {
+  //   info.data = e.data
+  //   pm.input.updatingComposition = true
+  //   inputText(pm, info.range, info.data)
+  //   pm.input.updatingComposition = false
+  //   info.range = new Range(info.range.from, info.range.from.shift(info.data.length))
+  // }
 }
 
 handlers.compositionend = (pm, e) => {

--- a/src/edit/selection.js
+++ b/src/edit/selection.js
@@ -242,7 +242,7 @@ function DOMFromPos(parent, pos) {
   if (!found) return {node: node, offset: 0}
   if (found.node.hasAttribute("pm-span-atom") || !(inner = leafAt(found.node, found.innerOffset)))
     return {node: found.parent, offset: found.offset + (found.innerOffset ? 1 : 0)}
-  else
+  else 
     return inner
 }
 
@@ -291,13 +291,21 @@ export function coordsAtPos(pm, pos) {
     range.setStart(node, offset ? offset - 1 : offset)
     rect = range.getBoundingClientRect()
   } else if (node.nodeType == 1 && node.firstChild) {
-    rect = node.childNodes[offset ? offset - 1 : offset].getBoundingClientRect()
-    // BR nodes are likely to return a useless empty rectangle. Try
-    // the node on the other side in that case.
-    if (rect.left == rect.right && offset && offset < node.childNodes.length) {
-      let otherRect = node.childNodes[offset].getBoundingClientRect()
-      if (otherRect.left != otherRect.right)
-        rect = {top: otherRect.top, bottom: otherRect.bottom, right: otherRect.left}
+    let childNode = node.childNodes[offset ? offset - 1 : offset]
+    if (childNode.nodeType === 1) {
+      rect = childNode.getBoundingClientRect()
+      // BR nodes are likely to return a useless empty rectangle. Try
+      // the node on the other side in that case.
+      if (rect.left == rect.right && offset && offset < node.childNodes.length) {
+        let otherRect = node.childNodes[offset].getBoundingClientRect()
+        if (otherRect.left != otherRect.right)
+          rect = {top: otherRect.top, bottom: otherRect.bottom, right: otherRect.left}
+      }
+    } else {
+      let range = document.createRange()
+      range.setEnd(childNode, 0)
+      range.setStart(childNode, 0)
+      rect = range.getBoundingClientRect()
     }
   } else {
     rect = node.getBoundingClientRect()


### PR DESCRIPTION
I got an error when I typed a chinese word in empty p element by using chinese input method.
```
node.childNodes[(intermediate value)(intermediate value)(intermediate value)].getBoundingClientRect is not a function
```

And I think the pm.doc shouldn't be updated because the composition of the Chinese word hasn't completed. For instance: A Chinese word "你"  is composed with three parts following「ㄋ」、「ㄧ」 and 「ˇ」. When the undo event is fired, it should directly delete the whole word.

I'm sorry about English is not my native language.