### PR TITLE
Fix undefined result of StyleMarker toJSON

### DIFF
--- a/src/model/style.js
+++ b/src/model/style.js
@@ -8,6 +8,7 @@ export class StyleMarker {
     if (this.type.instance) return this.type.name
     let obj = {_: this.type.name}
     for (let attr in this.attrs) obj[attr] = this.attrs[attr]
+    return obj
   }
 
   addToSet(set) {


### PR DESCRIPTION
This caused problems when sending a step containing link styles to the server as JSON and trying use Step.fromJSON on it.