### PR TITLE
Handle empty text in Schema nodeFromJSON

### DIFF
--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -368,7 +368,7 @@ export class Schema {
   nodeFromJSON(json) {
     let type = this.nodeType(json.type)
     return type.create(json.attrs,
-                       json.text || (json.content && json.content.map(this.nodeFromJSON)),
+                       typeof json.text == "string" ? json.text : (json.content && json.content.map(this.nodeFromJSON)),
                        json.styles && json.styles.map(this.styleFromJSON))
   }
 


### PR DESCRIPTION
Not explicitly checking for a string type returns false for empty strings. This results in a "Passing non-string as text node content" error in the TextNode constructor as undefined gets passed to the create method. This fix makes sure that empty strings are passed to the create method.

This problem occurred when for example pasting text from the clipboard containing three empty lines in a row.