### PR TITLE
Allow ProseMirror to load when window is undefined

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -21,8 +21,8 @@ function add(value, target) {
 }
 
 
-const reqFrame = window.requestAnimationFrame || window.mozRequestAnimationFrame ||
-      window.webkitRequestAnimationFrame || window.msRequestAnimationFrame
+const reqFrame =  typeof window !== 'undefined' && (window.requestAnimationFrame || window.mozRequestAnimationFrame ||
+      window.webkitRequestAnimationFrame || window.msRequestAnimationFrame)
 
 export function requestAnimationFrame(f) {
   if (reqFrame) reqFrame(f)

--- a/src/edit/map.js
+++ b/src/edit/map.js
@@ -1,4 +1,4 @@
-export const Map = window.Map || class {
+export const Map = (typeof window !== 'undefined' && window.Map) || class {
   constructor() { this.content = [] }
   set(key, value) {
     let found = this.find(key)


### PR DESCRIPTION
check for `window` before calling