### PR TITLE
allow A tag with name attribute (anchors) in default schema

### DIFF
--- a/src/model/defaultschema.js
+++ b/src/model/defaultschema.js
@@ -1,5 +1,5 @@
 import {SchemaSpec, Schema, Block, Textblock, Inline, Text,
-        Attribute, StyleType} from "./schema"
+        Attribute, StyleType, SchemaError} from "./schema"
 
 export class Doc extends Block {
   static get kind() { return "." }
@@ -62,8 +62,13 @@ export class LinkStyle extends StyleType {
   static get rank() { return  53 }
 }
 LinkStyle.attributes = {
-  href: new Attribute,
-  title: new Attribute({default: ""})
+  href: new Attribute({default: ""}),
+  name: new Attribute({compute: function(arg1, attrs){
+	  if (!attrs.href) {
+		SchemaError.raise("No value supplied for attribute name and href")
+	  }
+  }}),
+  title: new Attribute({default: ""}),
 }
 
 export class CodeStyle extends StyleType {

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -199,7 +199,7 @@ export class StyleType {
 
   create(attrs) {
     if (!attrs && this.instance) return this.instance
-    return new StyleMarker(this, buildAttrs(this.attrs, attrs, this))
+    return new StyleMarker(this, buildAttrs(this.attrs, attrs, this, attrs))
   }
 
   static getOrder(styles) {

--- a/src/parse/dom.js
+++ b/src/parse/dom.js
@@ -256,6 +256,7 @@ function inline(dom, context, style) {
 LinkStyle.register("parseDOM", {tag: "a", parse: (dom, context, style) => {
   inline(dom, context, style.create({
     href: dom.getAttribute("href"),
+    name: dom.getAttribute("name"),
     title: dom.getAttribute("title")
   }))
 }})

--- a/src/serialize/dom.js
+++ b/src/serialize/dom.js
@@ -204,7 +204,8 @@ def(CodeStyle, () => elt("code"))
 
 def(LinkStyle, style => {
   let dom = elt("a")
-  dom.setAttribute("href", style.attrs.href)
+  if (style.attrs.href) dom.setAttribute("href", style.attrs.href)
+  if (style.attrs.name) dom.setAttribute("name", style.attrs.name)
   if (style.attrs.title) dom.setAttribute("title", style.attrs.title)
   return dom
 })


### PR DESCRIPTION
the current default schema does not allow <a name="...">  (without a href attribute). when attempting to paste something which contains such anchor, the paste does not show up at all

I am not sure this fix is the right way of verifying at least one of name/href attribute is available, please enlighten me if there is a better approach of doing this. thanks