### PR TITLE
a11y: add `label` option to constructor to set `aria-label` on editor.

### DIFF
--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -49,6 +49,9 @@ export class ProseMirror {
     this.setDocInner(opts.docFormat ? convertFrom(this.schema, opts.doc, opts.docFormat, {document}) : opts.doc)
     draw(this, this.doc)
     this.content.contentEditable = true
+    if (opts.label) {
+      this.content.setAttribute('aria-label', opts.label)
+    }
 
     this.mod = Object.create(null)
     this.operation = null

--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -31,7 +31,9 @@ const options = {
 
   historyEventDelay: new Option(500),
 
-  commandParamHandler: new Option("default")
+  commandParamHandler: new Option("default"),
+
+  label: new Option(null)
 }
 
 export function defineOption(name, defaultValue, update, updateOnInit) {


### PR DESCRIPTION
allows somebody tabbing into a prosemirror to see/heac a descriptive
label for the contenteditable area set by prosemirror.