### PR TITLE
Prevent Accidental Clicks on the buttonmenu when it is hidden

### DIFF
--- a/src/menu/tooltip.js
+++ b/src/menu/tooltip.js
@@ -99,7 +99,7 @@ export class Tooltip {
   close() {
     if (this.isOpen) {
       this.isOpen = false
-      this.dom.style.opacity = this.pointer.style.opacity = 0
+      this.dom.style.display = this.pointer.style.display = 'none'
     }
   }
 }


### PR DESCRIPTION
Hi there!

I'm not sure if there is a use case for setting the opacity to 0, but for me it resulted in an invisible menu that interfered with my user experience because I designed the menu to cover up other content when visible.  If you're interested, I solved my problem by setting the display to 'none' so the menu wasn't clickable while invisible. 

I don't know if this breaks any contracts for your behavior or is against any of your coding practices, and if so I'd be happy to fix this up.  

Thanks!  Liking ProseMirror so far!