### PR TITLE
Give tooltip a larger z-index

### DIFF
--- a/src/menu/tooltip.js
+++ b/src/menu/tooltip.js
@@ -139,7 +139,7 @@ insertCSS(`
   transition: left 0.4s ease-out, top 0.4s ease-out, opacity 0.2s;
   opacity: 0;
 
-  z-index: 5;
+  z-index: 10;
 }
 
 .ProseMirror-tooltip-pointer-above {


### PR DESCRIPTION
so it won't cover by menu bar:

<img width="658" alt="screen shot 2015-12-05 at 8 16 44 pm" src="https://cloud.githubusercontent.com/assets/284820/11607707/27e36502-9b8d-11e5-8101-175c82f42f3d.png">