### PR TITLE
Add a helpful error message when attempting to set an option that isn’t defined

### DIFF
--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -97,6 +97,7 @@ export function initOptions(pm) {
 
 export function setOption(pm, name, value) {
   let desc = options[name]
+  if (desc === undefined) AssertionError.raise("Option '" + name + "' is not defined")
   if (desc.update === false) AssertionError.raise("Option '" + name + "' can not be changed")
   let old = pm.options[name]
   pm.options[name] = value

--- a/test/browser/test-options.js
+++ b/test/browser/test-options.js
@@ -39,3 +39,14 @@ test("no_init", pm => {
   pm.setOption("testOptionNoInit", "updated")
   cmp(pm.mod.testOptionNoInitUpdated, true)
 })
+
+test("invalid_option", pm => {
+  var error
+  try {
+    pm.setOption("doesNotExist", "isInvalid")
+  } catch (e) {
+    error = e
+  }
+  cmp(pm.getOption("doesNotExist"), undefined)
+  cmp(error.message, "Option 'doesNotExist' is not defined")
+})


### PR DESCRIPTION
Right now this throws `Uncaught TypeError: Cannot read property 'update' of undefined`. Hopefully this can help with diagnosing option name typos.