### PR TITLE
Don't depend on browser globals in DOM module

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -21,8 +21,9 @@ function add(value, target) {
 }
 
 
-const reqFrame = window.requestAnimationFrame || window.mozRequestAnimationFrame ||
-      window.webkitRequestAnimationFrame || window.msRequestAnimationFrame
+const global = typeof window === 'undefined' ? { navigator: {} } : window
+const reqFrame = global.requestAnimationFrame || global.mozRequestAnimationFrame ||
+      global.webkitRequestAnimationFrame || global.msRequestAnimationFrame
 
 export function requestAnimationFrame(f) {
   if (reqFrame) reqFrame(f)
@@ -30,15 +31,15 @@ export function requestAnimationFrame(f) {
 }
 
 
-const ie_upto10 = /MSIE \d/.test(navigator.userAgent)
-const ie_11up = /Trident\/(?:[7-9]|\d{2,})\..*rv:(\d+)/.exec(navigator.userAgent)
+const ie_upto10 = /MSIE \d/.test(global.navigator.userAgent)
+const ie_11up = /Trident\/(?:[7-9]|\d{2,})\..*rv:(\d+)/.exec(global.navigator.userAgent)
 
 export const browser = {
-  mac: /Mac/.test(navigator.platform),
+  mac: /Mac/.test(global.navigator.platform),
   ie_upto10,
   ie_11up,
   ie: ie_upto10 || ie_11up,
-  gecko: /gecko\/\d/i.test(navigator.userAgent)
+  gecko: /gecko\/\d/i.test(global.navigator.userAgent)
 }
 
 

--- a/test/test-dom.js
+++ b/test/test-dom.js
@@ -5,6 +5,7 @@ import {defTest} from "./tests"
 
 import xmlDOM from "xmldom"
 
+import {elt} from "../src/dom"
 import {defaultSchema as schema} from "../src/model"
 import {toDOM, fromDOM} from "../src/format"
 
@@ -33,6 +34,9 @@ function t(name, doc, dom) {
     cmpNode(doc, fromDOM(schema, derivedDOM.documentElement))
   })
 }
+
+if (typeof elt !== 'function')
+  throw new Failure("`elt` should be an exposed function from `dom`")
 
 t("simple",
   doc(p("hello")),


### PR DESCRIPTION
I've got a script that converts HTML to a ProseMirror document format in Node.js. I'm using `jsdom` for this, and it works great. However, I've now defined a custom schema, which reusing in both frontend and backend. This schema needs to use `elt` from the `dom` module. That module is using the `window` and `navigator` globals, which don't exist in node, which crashes my script.

This is a simple fix that makes sure it doesn't crash. I also added a kind of stupid test that just ensures that the module can be loaded in a node environment. Obviously feel free to refactor however you see fit.