### PR TITLE
Throw error on unsupported markdown token types

### DIFF
--- a/src/markdown/from_markdown.js
+++ b/src/markdown/from_markdown.js
@@ -113,7 +113,11 @@ class MarkdownParseState {
   parseTokens(toks) {
     for (let i = 0; i < toks.length; i++) {
       let tok = toks[i]
-      this.tokenTypes[tok.type](this, tok)
+      let tokenType = this.tokenTypes[tok.type]
+      if (!tokenType)
+        throw new Error("Token type `" + tok.type + "` not supported by Markdown parser")
+
+      tokenType(this, tok)
     }
   }
 

--- a/test/test-parse.js
+++ b/test/test-parse.js
@@ -1,3 +1,4 @@
+import {throws} from 'assert'
 import {doc, blockquote, pre, pre2, h1, h2, p, hr, li, ol, ul, em, strong, code, a, a2, br, img, dataImage} from "./build"
 import {cmpNode, cmpStr} from "./cmp"
 import {defTest} from "./tests"
@@ -63,3 +64,10 @@ t("break",
 t("horizontal_rule",
   "one two\n\n---\n\nthree",
   doc(p("one two"), hr, p("three")))
+
+defTest("parse_html_inline", () => {
+  throws(
+    () => fromMarkdown(schema, "Foo <em>bar</em>"),
+    /html_inline/
+  )
+})


### PR DESCRIPTION
Came across this error when trying to parse markdown to ProseMirror document format, and it took me a little debugging (:blush:) to find the documentation which states inline HTML is not supported.

So, while I realize this is actually documented, I'd prefer if the parser gave a more meaningful error that helped me figure out the problem. Hope you think this is an acceptable solution ;)
