### PR TITLE
Ignore invalid menuBar item names

### DIFF
--- a/src/menu/menubar.js
+++ b/src/menu/menubar.js
@@ -35,7 +35,9 @@ defineOption("menuBar", false, function(pm, value) {
 })
 
 function getItems(pm, items) {
-  return Array.isArray(items) ? items.map(getItems.bind(null, pm)) : pm.commands[items]
+  return Array.isArray(items)
+         ? items.map(getItems.bind(null, pm)).filter(i => i)
+         : pm.commands[items]
 }
 
 class BarDisplay {


### PR DESCRIPTION
Currently if I pass an invalid item name into the menuBar option, I get a slightly cryptic error from deep inside the menu rendering code: `Uncaught TypeError: Cannot read property 'select' of undefined`.

This PR does two things: 1) Filter items which are not found in `pm.commands` (i.e. are undefined), 2) warn the user that they specified something invalid.

I don't see any other instances of you logging stuff to the console (and the linter doesn't like it), but I thought this was a nicer result than throwing a hard error. Thoughts?

**Updated**: see comment