### PR TITLE
Change duplicating var names in scope - es6ify issue

### DIFF
--- a/src/model/fragment.js
+++ b/src/model/fragment.js
@@ -391,9 +391,9 @@ class TextFragment extends Fragment {
   child(off) {
     if (off < 0 || off >= this.size) ModelError.raise("Offset " + off + " out of range")
     for (let i = 0, curOff = 0; i < this.content.length; i++) {
-      let child = this.content[i]
-      curOff += child.width
-      if (curOff > off) return child
+      let _child = this.content[i]
+      curOff += _child.width
+      if (curOff > off) return _child
     }
   }
 

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -640,7 +640,7 @@ export class Schema {
     for (let i = 0; i < 2; i++) {
       let obj = i ? this.marks : this.nodes
       for (let tname in obj) {
-        let type = obj[tname], registry = type.registry, ns = registry && registry[namespace]
+        let type = obj[tname], _registry = type.registry, ns = _registry && _registry[namespace]
         if (ns) for (let prop in ns) {
           let value = ns[prop](type)
           if (value != null) f(prop, value, type, tname)

--- a/src/transform/map.js
+++ b/src/transform/map.js
@@ -206,8 +206,8 @@ export class Remapping {
     let deleted = false
 
     for (let i = -this.head.length; i < this.tail.length; i++) {
-      let map = this.get(i)
-      let result = map.map(pos, bias)
+      let _map = this.get(i)
+      let result = _map.map(pos, bias)
       if (result.recover) {
         let corr = this.mirror[i]
         if (corr != null) {


### PR DESCRIPTION
Some of this code is processed by my app on server side. While babel has no problem with it, es6ify is bit more picky about repeating var names in the same scope. Over here we have situation that we name vars same as named functions. That blocks transformation. Cosmetic change, but helps a lot.