### PR TITLE
Pipelined event to transform paste after it has been parsed

### DIFF
--- a/src/edit/input.js
+++ b/src/edit/input.js
@@ -366,6 +366,8 @@ function getCopied(pm, dataTransfer, plainText) {
     doc = parseFrom(pm.schema, pm.signalPipelined("transformPastedText", txt),
                     knownSource("markdown") ? "markdown" : "text")
   }
+  doc = pm.signalPipelined("transformPastedParsed", doc)
+
   return {doc, from: findSelectionAtStart(doc).from, to: findSelectionAtEnd(doc).to}
 }
 


### PR DESCRIPTION
My use case for this is to do something like:

```
	function forTextblocks(node, callback, path = []) {
		if(node.isTextblock) {
			callback(node, path)
		} else if (node.contains === "block") { 
			node.content.forEach((child, i) => forTextblocks(child, callback, [].concat(path, i)))
		}
	}

	pm.on("transformPastedParsed", function(doc) {

		forTextblocks(doc, (node, path) => {
			if(node.textContent.trim().match(/^(?:http(?:s)?:\/\/)?(?:www\.)?twitter\.com\/(?:(?:\w)*#!\/)?(?:pages\/)?(?:[\w\-]*\/)*([\w\-]*)$/)) {
				path = [].concat(path)
				let index = path.pop()
				let tr = new Transform(doc)
				tr.replaceWith(new Pos(path,index), new Pos(path,index + 1), pm.schema.node('tweet', {tweetUrl:node.textContent.trim()}))
				doc = tr.doc
			}
		})
		return doc;

	})
```

It should also be useful for applying inputrules to pasted content, although that might need some work as the current suggestion is to end their regexp in $