### PR TITLE
Update icons.js

### DIFF
--- a/src/menu/icons.js
+++ b/src/menu/icons.js
@@ -18,7 +18,7 @@ export function getIcon(name, data) {
     let use = svg.appendChild(document.createElementNS(SVG, "use"))
     use.setAttributeNS(XLINK, "href", "#pm-icon-" + name)
   } else {
-    node.appendChild(document.createElement("span")).textContent = data.text
+    node.appendChild(document.createElement("span")).textContent = data.text || ''
     if (data.css) node.firstChild.style.cssText = data.css
   }
   return node


### PR DESCRIPTION
Safari sets content to `undefined`, this just passes an empty string if `data.text` is undefined