### PR TITLE
Clarify defineOption doc

### DIFF
--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -17,9 +17,9 @@ const options = Object.create(null)
 // :: (string, any, (pm: ProseMirror, newValue: any, oldValue: any, init: bool), bool)
 // Define a new option. The `update` handler will be called with the
 // option's old and new value every time the option is
-// [changed](#ProseMirror.setOption). When `updateOnInit` is true, it
-// is also called on editor init, with null as the old value, and a fourth
-// argument of true.
+// [changed](#ProseMirror.setOption). When `updateOnInit` is false, it
+// will not be called on editor init, otherwise it is called with null as the old value,
+// and a fourth argument of true.
 export function defineOption(name, defaultValue, update, updateOnInit) {
   options[name] = new Option(defaultValue, update, updateOnInit)
 }


### PR DESCRIPTION
The documentation of defineOption felt a bit misleading. Because of `this.updateOnInit = updateOnInit !== false` in the `Option` constructor, if no value is sent it defaults to true. Clarified the wording to better indicate that you must explicitly send false to *not* run on init