### PR TITLE
Pass options to Markdown Parser / Serializer

### DIFF
--- a/src/markdown/from_markdown.js
+++ b/src/markdown/from_markdown.js
@@ -6,14 +6,14 @@ import {defineSource} from "../format"
 import {AssertionError} from "../util/error"
 import sortedInsert from "../util/sortedinsert"
 
-// :: (Schema, string) → Node
+// :: (Schema, string, ?options) → Node
 // Parse a string as [CommonMark](http://commonmark.org/) markup, and
 // create a ProseMirror document corresponding to its meaning. Note
 // that, by default, some CommonMark features, namely inline HTML and
 // tight lists, are not supported.
-export function fromMarkdown(schema, text) {
+export function fromMarkdown(schema, text, options) {
   let tokens = configureMarkdown(schema).parse(text, {})
-  let state = new MarkdownParseState(schema, tokens), doc
+  let state = new MarkdownParseState(schema, tokens, options), doc
   state.parseTokens(tokens)
   do { doc = state.closeNode() } while (state.stack.length)
   return doc
@@ -82,7 +82,7 @@ function maybeMerge(a, b) {
 // and to expose parsing-related methods to node-specific parsing
 // functions.
 class MarkdownParseState {
-  constructor(schema, tokens) {
+  constructor(schema, tokens, options) {
     // :: Schema
     // The schema into which we are parsing.
     this.schema = schema
@@ -90,6 +90,7 @@ class MarkdownParseState {
     this.tokens = tokens
     this.marks = noMarks
     this.tokenTypes = tokenTypeInfo(schema)
+    this.options = options
   }
 
   top() {

--- a/src/markdown/to_markdown.js
+++ b/src/markdown/to_markdown.js
@@ -3,7 +3,7 @@ import {Text, BlockQuote, OrderedList, BulletList, ListItem,
         EmMark, StrongMark, LinkMark, CodeMark} from "../model"
 import {defineTarget} from "../format"
 
-// :: (Node) → string
+// :: (Node, ?options) → string
 // Serialize the content of the given node to [CommonMark](http://commonmark.org/).
 //
 // To define serialization behavior for your own [node
@@ -15,8 +15,8 @@ import {defineTarget} from "../format"
 // `closeMarkdown` properties, which provide the markup text that
 // marked content should be wrapped in. They may hold either a string
 // or a function from a `MarkdownSerializer` and a `Mark` to a string.
-export function toMarkdown(doc) {
-  let state = new MarkdownSerializer
+export function toMarkdown(doc, options) {
+  let state = new MarkdownSerializer(options)
   state.renderContent(doc)
   return state.out
 }
@@ -27,10 +27,11 @@ defineTarget("markdown", toMarkdown)
 // methods related to markdown serialization. Instances are passed to
 // node and mark serialization methods (see `toMarkdown`).
 class MarkdownSerializer {
-  constructor() {
+  constructor(options) {
     this.delim = this.out = ""
     this.closed = false
     this.inTightList = false
+    this.options = options
   }
 
   flushClose(size) {


### PR DESCRIPTION
I have a use case where the `src` of an image must be modified when converting from/to markdown (e.g. the original markdown file at the local filesystem contains images located in the same folder, but after import into ProseMirror, the image needs to be served from an image server or otherwise custom location. For export, the image `src` must be changed back again). 

Instead of using `ProseMirror.getContent()` / `ProseMirror.setContent()` I use `parseFrom` and `serializeTo` which allow to pass options through, and then one can easily just overwrite the serializer / parser method for the relevant model, e.g.:

```
import { Image } from "prosemirror/dist/model"

Image.register("parseMarkdown", "image", {parse: function(state, tok) {
  // we have now access to:  state.options
 ...
}})
```