### PR TITLE
Fixes a bug with setNodeSelection and pm.on("selectionChange", funct…

### DIFF
--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -119,7 +119,7 @@ export class ProseMirror {
     if (!node.type.selectable)
       SelectionError.raise("Trying to select a non-selectable node")
     this.input.maybeAbortComposition()
-    this.sel.setAndSignal(new NodeSelection(pos, pos.move(1), node))
+    this.sel.setAndSignal(new NodeSelection(pos, pos.move(1), node), false)
   }
 
   // :: (Selection)


### PR DESCRIPTION
### Problem 

Currently, when I have the follow code in my project

```
pm.on('selectionChange', function() { let selection = pm.selection })
```

Place the cursor in text and then try to select a block node. The selection remains in the text.

### Analysis

I've debugged the code and what is happening is that when the node selection is set `pm.sel.lastAnchorNode` gets set to null in `seleciton::set` as no `clearLast` parameter is sent to `selection::setAndSignal`.  When I access `pm.selection` in the "selectionChange" event, `ensureOperation` calls `startOperation` which calls `this.sel.readFromDOM()`

In `selection::readFromDOM` the first check should ideally evaluate to true so that it exits and doesn't replace the node selection. `!this.domChanged()` evaluates to false because `lastAnchorNode` was set to null. So `readFromDOM` proceeds and sets the selection back to the previous text selection which still exists in the DOM as `nodeToDOM` hasn't been called form redraw yet.

### Solution

It seems the solution would either be to pass false for `clearLast` in `setAndSignal` on set so that `readFromDOM` will exit OR to properly reflect the selection in the dom by calling `nodeToDOM` between `set` and `signal`. I wasn't sure if calling `nodeToDOM` outside of redraw was an acceptable thing to do, also technically the browser selection hasn't yet changed, so I went with the former option.
