### PR TITLE
Minor additions to UI, which makes customizing easier

### DIFF
--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -219,7 +219,11 @@ function renderDropdownItems(items, pm) {
   let rendered = []
   for (let i = 0; i < items.length; i++) {
     let inner = items[i].render(pm)
-    if (inner) rendered.push(elt("div", {class: prefix + "-dropdown-item"}, inner))
+    if (inner) {
+      let element = elt("div", {class: prefix + "-dropdown-item"}, inner)
+      if (items[i].command_) element.setAttribute("data-cmd", items[i].command_.name)
+      rendered.push(element)
+    }
   }
   if (!rendered.length) rendered.push(elt("div", {class: prefix + "-dropdown-empty"}, "(empty)"))
   return rendered

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -75,6 +75,7 @@ export class MenuCommand {
       AssertionError.raise("Unsupported command display style: " + disp.type)
     }
     dom.setAttribute("title", title(pm, cmd))
+    dom.setAttribute("data-cmd", cmd.name)
     if (this.options.class) dom.classList.add(this.options.class)
     if (disabled) dom.classList.add(prefix + "-disabled")
     if (this.options.css) dom.style.cssText += this.options.css

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -33,6 +33,10 @@ function title(pm, command) {
   return key ? command.label + " (" + key + ")" : command.label
 }
 
+function getCommandData(command) {
+  return typeof command === "string" ? command : command.name
+}
+
 // ;; Wraps a [command](#Command) so that it can be rendered in a
 // menu.
 export class MenuCommand {
@@ -221,7 +225,7 @@ function renderDropdownItems(items, pm) {
     let inner = items[i].render(pm)
     if (inner) {
       let element = elt("div", {class: prefix + "-dropdown-item"}, inner)
-      if (items[i].command_) element.setAttribute("data-cmd", items[i].command_.name)
+      if (items[i].command_) element.setAttribute("data-cmd", getCommandData(items[i].command_))
       rendered.push(element)
     }
   }
@@ -291,7 +295,7 @@ export function renderGrouped(pm, content) {
       if (rendered) {
         if (!added && needSep) result.appendChild(separator())
         let menuItem = elt("span", {class: prefix + "item"}, rendered)
-        if (items[j].command_) menuItem.setAttribute("data-cmd", items[j].command_.name)
+        if (items[j].command_) menuItem.setAttribute("data-cmd", getCommandData(items[j].command_))
         result.appendChild(menuItem)
         added = true
       }

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -75,7 +75,6 @@ export class MenuCommand {
       AssertionError.raise("Unsupported command display style: " + disp.type)
     }
     dom.setAttribute("title", title(pm, cmd))
-    dom.setAttribute("data-cmd", cmd.name)
     if (this.options.class) dom.classList.add(this.options.class)
     if (disabled) dom.classList.add(prefix + "-disabled")
     if (this.options.css) dom.style.cssText += this.options.css
@@ -287,7 +286,9 @@ export function renderGrouped(pm, content) {
       let rendered = items[j].render(pm)
       if (rendered) {
         if (!added && needSep) result.appendChild(separator())
-        result.appendChild(elt("span", {class: prefix + "item"}, rendered))
+        let menuItem = elt("span", {class: prefix + "item"}, rendered)
+        if (items[j].command_) menuItem.setAttribute("data-cmd", items[j].command_.name)
+        result.appendChild(menuItem)
         added = true
       }
     }

--- a/src/ui/prompt.js
+++ b/src/ui/prompt.js
@@ -31,7 +31,7 @@ export class ParamPrompt {
         AssertionError.raise("Unsupported parameter type: " + param.type)
       return this.paramTypes[param.type].render.call(this.pm, param, this.defaultValue(param))
     })
-    let promtTitle = elt("h5", {}, (command.spec && command.spec.label) ? command.spec.label : '')
+    let promptTitle = elt("h5", {}, (command.spec && command.spec.label) ? command.spec.label : '')
     let submitButton = elt("button", {type: "submit", class: "ProseMirror-prompt-submit"}, "Ok")
     let cancelLink = elt("a", {class: "ProseMirror-prompt-cancel"}, "Cancel")
     // :: DOMNode

--- a/src/ui/prompt.js
+++ b/src/ui/prompt.js
@@ -31,11 +31,12 @@ export class ParamPrompt {
         AssertionError.raise("Unsupported parameter type: " + param.type)
       return this.paramTypes[param.type].render.call(this.pm, param, this.defaultValue(param))
     })
+    let promtTitle = elt("h5", {}, (command.spec && command.spec.label) ? command.spec.label : '')
     let submitButton = elt("button", {type: "submit", class: "ProseMirror-prompt-submit"}, "Ok")
     let cancelLink = elt("a", {class: "ProseMirror-prompt-cancel"}, "Cancel")
     // :: DOMNode
     // An HTML form wrapping the fields.
-    this.form = elt("form", null, this.fields.map(f => elt("div", null, f)), submitButton, cancelLink)
+    this.form = elt("form", null, promtTitle, this.fields.map(f => elt("div", null, f)), submitButton, cancelLink)
   }
 
   // :: ()
@@ -241,6 +242,10 @@ insertCSS(`
   position: absolute;
   border-radius: 3px;
   z-index: 11;
+}
+
+.ProseMirror-prompt h5 {
+  display:none;
 }
 
 .ProseMirror-prompt input[type="text"],

--- a/src/ui/prompt.js
+++ b/src/ui/prompt.js
@@ -31,9 +31,11 @@ export class ParamPrompt {
         AssertionError.raise("Unsupported parameter type: " + param.type)
       return this.paramTypes[param.type].render.call(this.pm, param, this.defaultValue(param))
     })
+    let submitButton = elt("button", {type: "submit", class: "ProseMirror-prompt-submit"}, "Ok")
+    let cancelLink = elt("a", {class: "ProseMirror-prompt-cancel"}, "Cancel")
     // :: DOMNode
     // An HTML form wrapping the fields.
-    this.form = elt("form", null, this.fields.map(f => elt("div", null, f)))
+    this.form = elt("form", null, this.fields.map(f => elt("div", null, f)), submitButton, cancelLink)
   }
 
   // :: ()
@@ -74,6 +76,10 @@ export class ParamPrompt {
         prompt.close()
       else if (e.keyCode == 13 && !(e.ctrlKey || e.metaKey || e.shiftKey))
         submit()
+    })
+
+    this.form.querySelector('.ProseMirror-prompt-cancel').addEventListener("click", e => {
+      prompt.close()
     })
 
     let input = this.form.querySelector("input, textarea")
@@ -258,6 +264,11 @@ insertCSS(`
 .ProseMirror-prompt-close:after {
   content: "✕";
   font-size: 12px;
+}
+
+.ProseMirror-prompt-submit,
+.ProseMirror-prompt-cancel {
+  display: none;
 }
 
 .ProseMirror-invalid {

--- a/src/ui/prompt.js
+++ b/src/ui/prompt.js
@@ -79,7 +79,7 @@ export class ParamPrompt {
         submit()
     })
 
-    this.form.querySelector('.ProseMirror-prompt-cancel').addEventListener("click", e => {
+    this.form.querySelector('.ProseMirror-prompt-cancel').addEventListener("click", () => {
       prompt.close()
     })
 

--- a/src/ui/prompt.js
+++ b/src/ui/prompt.js
@@ -36,7 +36,7 @@ export class ParamPrompt {
     let cancelLink = elt("a", {class: "ProseMirror-prompt-cancel"}, "Cancel")
     // :: DOMNode
     // An HTML form wrapping the fields.
-    this.form = elt("form", null, promtTitle, this.fields.map(f => elt("div", null, f)), submitButton, cancelLink)
+    this.form = elt("form", null, promptTitle, this.fields.map(f => elt("div", null, f)), submitButton, cancelLink)
   }
 
   // :: ()


### PR DESCRIPTION
Added some really minor properties and unobtrusive additions to the UI elements of the menu and prompt components, which add some UX goodness, and make them more customizable from CSS for example.

Such as:
- every menuitem has it's command in a data property
- add a submit and a cancel action to the prompt, additional to the closing X
- the prompt contains a title, from the action command name

These are all hidden by default in the CSS, so existing demos and usecases are not supposed to be affected.