### PR TITLE
Add option docs

### DIFF
--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -4,9 +4,15 @@ import {ParamPrompt} from "../ui/prompt"
 
 import {CommandSet, updateCommands} from "./command"
 
+// An option encapsulates functionality for an editor instance,
+// e.g. the amount of history events that the editor should hold
+// onto or the document's schema.
 class Option {
   constructor(defaultValue, update, updateOnInit) {
     this.defaultValue = defaultValue
+    // A function that will be invoked with the option's old and new
+    // value every time the option is [set](#ProseMirror.setOption).
+    // This function should bootstrap option functionality.
     this.update = update
     this.updateOnInit = updateOnInit !== false
   }


### PR DESCRIPTION
Tried to spell out what an option is, at least in a vague manner for the moment. 


Options seem to be the preferred way to offer custom functionality for an instance (i.e. for plugin authors), but it's probably too early to spell that out.