### PR TITLE
Add an optional translate function

### DIFF
--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -517,9 +517,9 @@ export class ProseMirror {
   // Return a translated string, if a translate function has been supplied,
   // or the original string.
   translate(string) {
-    return (typeof this._translate === "function")
-      ? this._translate(string)
-      : `${string}`
+    return (typeof this.options.translate === "function")
+      ? this.options.translate(string)
+      : string
   }
 }
 

--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -512,6 +512,15 @@ export class ProseMirror {
   markAllDirty() {
     this.dirtyNodes.set(this.doc, DIRTY_REDRAW)
   }
+
+  // :: (string) → string
+  // Return a translated string, if a translate function has been supplied,
+  // or the original string.
+  translate(string) {
+    return (typeof this._translate === "function")
+      ? this._translate(string)
+      : `${string}`
+  }
 }
 
 // :: Object

--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -79,6 +79,12 @@ defineOption("commandParamPrompt", ParamPrompt)
 // `aria-label` attribute with this value.
 defineOption("label", null)
 
+// :: ?function #path=translate #kind=option
+// Optional function to translate strings such as menu labels and prompts.
+// When set, should be a function that takes a string as argument and returns
+// a string, i.e. :: (string) → string
+defineOption("translate", null, (pm, value) => { pm._translate = value}, true)
+
 export function parseOptions(obj) {
   let result = Object.create(null)
   let given = obj ? [obj].concat(obj.use || []) : []

--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -83,7 +83,7 @@ defineOption("label", null)
 // Optional function to translate strings such as menu labels and prompts.
 // When set, should be a function that takes a string as argument and returns
 // a string, i.e. :: (string) → string
-defineOption("translate", null, (pm, value) => { pm._translate = value}, true)
+defineOption("translate", null)
 
 export function parseOptions(obj) {
   let result = Object.create(null)

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -29,8 +29,9 @@ const prefix = "ProseMirror-menu"
 
 function title(pm, command) {
   if (!command.label) return null
+  let label = pm.translate(command.label)
   let key = command.name && pm.keyForCommand(command.name)
-  return key ? command.label + " (" + key + ")" : command.label
+  return key ? label + " (" + key + ")" : label
 }
 
 // ;; Wraps a [command](#Command) so that it can be rendered in a
@@ -74,7 +75,8 @@ export class MenuCommand {
       dom = getIcon(cmd.name, disp)
       if (!disabled && cmd.active(pm)) dom.classList.add(prefix + "-active")
     } else if (disp.type == "label") {
-      dom = elt("div", null, disp.label || cmd.spec.label)
+      let label = pm.translate(disp.label || cmd.spec.label)
+      dom = elt("div", null, label)
     } else {
       throw new AssertionError("Unsupported command display style: " + disp.type)
     }
@@ -173,6 +175,7 @@ export class Dropdown {
     if (!items.length) return
 
     let label = (this.options.activeLabel && this.findActiveIn(this, pm)) || this.options.label
+    label = pm.translate(label)
     let dom = elt("div", {class: prefix + "-dropdown " + (this.options.class || ""),
                           style: this.options.css,
                           title: this.options.title}, label)
@@ -253,7 +256,7 @@ export class DropdownSubmenu {
     let items = renderDropdownItems(resolveGroup(pm, this.content), pm)
     if (!items.length) return
 
-    let label = elt("div", {class: prefix + "-submenu-label"}, this.options.label)
+    let label = elt("div", {class: prefix + "-submenu-label"}, pm.translate(this.options.label))
     let wrap = elt("div", {class: prefix + "-submenu-wrap"}, label,
                    elt("div", {class: prefix + "-submenu"}, items))
     label.addEventListener("mousedown", e => {

--- a/src/ui/prompt.js
+++ b/src/ui/prompt.js
@@ -31,7 +31,7 @@ export class ParamPrompt {
         throw new AssertionError("Unsupported parameter type: " + param.type)
       return this.paramTypes[param.type].render.call(this.pm, param, this.defaultValue(param))
     })
-    let promptTitle = elt("h5", {}, (command.spec && command.spec.label) ? command.spec.label : "")
+    let promptTitle = elt("h5", {}, (command.spec && command.spec.label) ? pm.translate(command.spec.label) : "")
     let submitButton = elt("button", {type: "submit", class: "ProseMirror-prompt-submit"}, "Ok")
     let cancelButton = elt("button", {type: "button", class: "ProseMirror-prompt-cancel"}, "Cancel")
     cancelButton.addEventListener("click", () => this.close())
@@ -183,8 +183,9 @@ ParamPrompt.prototype.paramTypes = Object.create(null)
 
 ParamPrompt.prototype.paramTypes.text = {
   render(param, value) {
+    let label = this.translate(param.label)
     return elt("input", {type: "text",
-                         placeholder: param.label,
+                         placeholder: label,
                          value,
                          autocomplete: "off"})
   },
@@ -195,8 +196,9 @@ ParamPrompt.prototype.paramTypes.text = {
 
 ParamPrompt.prototype.paramTypes.select = {
   render(param, value) {
+    let translate = this.translate.bind(this)
     let options = param.options.call ? param.options(this) : param.options
-    return elt("select", null, options.map(o => elt("option", {value: o.value, selected: o.value == value ? "true" : null}, o.label)))
+    return elt("select", null, options.map(o => elt("option", {value: o.value, selected: o.value == value ? "true" : null}, translate(o.label))))
   },
   read(dom) {
     return dom.value


### PR DESCRIPTION
Add a translate function in the options, which will get every label, and
optionally return a translated string. Used in menus and prompts.