### PR TITLE
Empty textnode error

### DIFF
--- a/src/model/node.js
+++ b/src/model/node.js
@@ -1,6 +1,7 @@
 import {Fragment, emptyFragment} from "./fragment"
 import {Mark} from "./mark"
 import {Pos} from "./pos"
+import {SchemaError} from "./schema"
 
 const emptyArray = [], emptyAttrs = Object.create(null)
 
@@ -362,6 +363,9 @@ if (typeof Symbol != "undefined") {
 export class TextNode extends Node {
   constructor(type, attrs, content, marks) {
     super(type, attrs, null, marks)
+
+    if(content === "") throw new SchemaError("Empty text nodes are forbidden. Consider checking content prior to instantiating.")
+
     // :: ?string
     // For text nodes, this contains the node's text content.
     this.text = content

--- a/src/model/node.js
+++ b/src/model/node.js
@@ -364,7 +364,7 @@ export class TextNode extends Node {
   constructor(type, attrs, content, marks) {
     super(type, attrs, null, marks)
 
-    if(content === "") throw new SchemaError("Empty text nodes are forbidden. Consider checking content prior to instantiating.")
+    if(!content) throw new SchemaError("Empty text nodes are forbidden. Consider checking content prior to instantiating.")
 
     // :: ?string
     // For text nodes, this contains the node's text content.

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -598,7 +598,7 @@ export class Schema {
   }
 
   // :: (string, ?[Mark]) → Node
-  // Create a text node in the schema. This method is bound to the Schema.
+  // Create a text node in the schema. This method is bound to the Schema. Empty text nodes are not allowed.
   text(text, marks) {
     return this.nodes.text.create(null, text, Mark.setFrom(marks))
   }


### PR DESCRIPTION
- Throw an error if a text node is constructed with empty content
- Document that text nodes cannot be empty