### PR TITLE
Fixes bug when an event handler unbinds itself

### DIFF
--- a/src/util/event.js
+++ b/src/util/event.js
@@ -25,8 +25,11 @@ const methods = {
   // arguments.
   signal(type, ...args) {
     let arr = this._handlers && this._handlers[type]
-    if (arr) for (let i = 0; i < arr.length; ++i)
-      arr[i](...args)
+    if (arr) {
+      arr = [].concat(arr)
+      for (let i = 0; i < arr.length; ++i)
+        arr[i](...args)
+    }
   },
 
   // :: (type: string, ...args: [any]) → any #path=EventMixin.signalHandleable


### PR DESCRIPTION
If an event handler unbinds itself the handler immediately following in the handler list will be skipped. This patch iterates over a copy of the handler list so mutations to the original will not affect it. 

Discovered this from a piece of functionality we wrote that did:

```
function onTransform() {
  pm.off("transform", onTransform) //unbind to prevent this being called from subsequent lines
  //execute some code that might transform
  pm.on("transform", onTransform)
}

pm.on("transform", onTransform)
```

I don't love this code, but it's just a stopgap for now. The fact remains that any handler that unbound itself would run into this bug.