### PR TITLE
Fix "undefined" binding when using Array.prototype.all

### DIFF
--- a/src/edit/command.js
+++ b/src/edit/command.js
@@ -254,9 +254,12 @@ function deriveKeymap(pm) {
   for (let name in pm.commands) {
     let cmd = pm.commands[name], keys = cmd.spec.keys
     if (!keys) continue
-    if (Array.isArray(keys)) add(cmd, keys)
-    if (keys.all) add(cmd, keys.all)
-    if (keys[platform]) add(cmd, keys[platform])
+    if (Array.isArray(keys)) {
+      add(cmd, keys)
+    } else {
+      if (keys.all) add(cmd, keys.all)
+      if (keys[platform]) add(cmd, keys[platform])
+    }
   }
 
   for (let key in bindings)


### PR DESCRIPTION
Our environment includes `Array.prototype.all` method with `length === 1`. When `cmd.spec.keys` is array, both `Array.isArray(keys)` and `keys.all` evaluates to `true`, which leads to adding `"undefined"` string to key bindings.

```javascript
if (Array.isArray(keys)) add(cmd, keys) // typeof keys === array
if (keys.all) add(cmd, keys.all) // typeof keys.all === function
```

```javascript
function add(command, keys) { // typeof keys === function
    for (let i = 0; i < keys.length; i++) { // keys.length === 1 (one argument)
      let [_, name, rank = 50] = /^(.+?)(?:\((\d+)\))?$/.exec(keys[i])
      // keys[i] === undefined and thus name === "undefined"
      ...
    }
  }
```

This PR fixes this problem: when `cmd.spec.keys` is array, skip checking `keys.all` and `keys[platform]`.
Tests and lint check passed.