### PR TITLE
Add inclusiveLeft and inclusiveRight properties to MarkType

### DIFF
--- a/src/collab/index.js
+++ b/src/collab/index.js
@@ -68,13 +68,13 @@ class Collab {
     pm.on("beforeSetDoc", this.onSetDoc = () => {
       throw new AssertionError("setDoc is not supported on a collaborative editor")
     })
-    pm.history.allowCollapsing = false
+    pm.history.preserveMaps++
   }
 
   detach() {
     this.pm.off("transform", this.onTransform)
     this.pm.off("beforeSetDoc", this.onSetDoc)
-    this.pm.history.allowCollapsing = true
+    this.pm.history.preserveMaps--
   }
 
   // :: () → bool

--- a/src/collab/rebase.js
+++ b/src/collab/rebase.js
@@ -9,7 +9,7 @@ export function rebaseSteps(doc, forward, steps, maps) {
     let step = steps[i].map(remap)
     let result = step && transform.step(step)
     let id = remap.addToFront(maps[i].invert())
-    if (result) {
+    if (result && result.doc) {
       remap.addToBack(step.posMap(), id)
       positions.push(transform.steps.length - 1)
     } else {

--- a/src/model/node.js
+++ b/src/model/node.js
@@ -203,13 +203,36 @@ export class Node {
   resolveNoCache(pos) { return resolvePos(this, pos) }
 
   // :: (number) → [Mark]
-  // Get the marks of the node before the given position or, if that
-  // position is at the start of a non-empty node, those of the node
-  // after it.
+  // Get the marks at the given position factoring in the surrounding marks'
+  // inclusiveLeft and inclusiveRight properties. If the position is at the
+  // start of a non-empty node, the marks of the node after it are returned.
   marksAt(pos) {
     let $pos = this.resolve(pos), top = $pos.parent, index = $pos.index($pos.depth)
-    let leaf = $pos.offset($pos.depth) == $pos.parentOffset && index ? top.child(index - 1) : top.maybeChild(index)
-    return leaf ? leaf.marks : emptyArray
+
+    // pos is inside a fragment
+    if ($pos.offset($pos.depth) != $pos.parentOffset)
+      return top.child(index).marks
+
+    // pos is at the start of a potentially non-empty node
+    if (index == 0) {
+      let rightLeaf = top.maybeChild(index)
+      return rightLeaf ? rightLeaf.marks : emptyArray
+    }
+
+    // pos is inbetween two fragments or at the end of a non-empty node
+    let marks = []
+    let leftLeaf = top.child(index - 1)
+    for (let i = 0; i < leftLeaf.marks.length; i++) {
+      if (leftLeaf.marks[i].type.inclusiveRight) marks.push(leftLeaf.marks[i])
+    }
+
+    let rightLeaf = top.maybeChild(index)
+    if (rightLeaf) for (let i = 0; i < rightLeaf.marks.length; i++) {
+      if (rightLeaf.marks[i].type.inclusiveLeft && marks.indexOf(rightLeaf.marks[i]) == -1)
+        marks.push(rightLeaf.marks[i])
+    }
+
+    return marks.length ? marks : emptyArray
   }
 
   // :: (?number, ?number, MarkType) → bool

--- a/src/model/schema.js
+++ b/src/model/schema.js
@@ -475,6 +475,16 @@ export class MarkType extends SchemaItem {
   // guarantee what it will be.)
   static get rank() { return 50 }
 
+  // :: bool
+  // Whether this mark should be active when the cursor is positioned
+  // at the start of the mark.
+  get inclusiveLeft() { return false }
+
+  // :: bool
+  // Whether this mark should be active when the cursor is positioned
+  // at the end of the mark.
+  get inclusiveRight() { return true }
+
   // :: (?Object) → Mark
   // Create a mark of this type. `attrs` may be `null` or an object
   // containing only some of the mark's attributes. The others, if


### PR DESCRIPTION
This is an initial implementation regarding issue #285. I'm currently not sure how to best handle the edge case of putting the cursor at the start of a non-empty node. My suggestion would be to only keep the marks of the right leaf that have `inclusiveLeft` set to `true` or `inclusiveRight` set to `false`. This is not how this edge case is currently handled in my code as I first want to get feedback on this.