### PR TITLE
Do not prevent default copy/cut behavior on iOS

### DIFF
--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -36,6 +36,7 @@ const ie_11up = /Trident\/(?:[7-9]|\d{2,})\..*rv:(\d+)/.exec(navigator.userAgent
 
 export const browser = {
   mac: /Mac/.test(navigator.platform),
+  ios:/(iPod|iPhone|iPad)/.test(navigator.userAgent),
   ie_upto10,
   ie_11up,
   ie: ie_upto10 || ie_11up,

--- a/src/edit/input.js
+++ b/src/edit/input.js
@@ -430,7 +430,8 @@ handlers.copy = handlers.cut = (pm, e) => {
   let {from, to, empty} = pm.selection
   if (empty || !e.clipboardData) return
   toClipboard(pm.doc, from, to, e.clipboardData)
-  e.preventDefault()
+  if (!browser.ios)
+    e.preventDefault()
   if (e.type == "cut" && !empty)
     pm.tr.delete(from, to).apply()
 }


### PR DESCRIPTION
I'm not 100% sure, but this might be a fix for #295.

From my understanding, the problem is that `DataTransfer.setData` just does nothing. I couldn't find anything useful on the internet except the [MDN page](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/setData#Browser_compatibility) which says it's not supported.

The only problem with this change I could find is that only `text/plain` part is copied and can be pasted later.

Any feedback is appreciated, thanks!