### PR TITLE
Simplify canWrap, correct type docs

### DIFF
--- a/src/edit/command.js
+++ b/src/edit/command.js
@@ -408,7 +408,7 @@ NodeType.derivableCommands.wrap = function(conf) {
       if (conf.list && head && isAtTopOfListItem(pm.doc, from, to, this) &&
           ($from = pm.doc.resolve(from)).index($from.depth - 2) == 0)
         return false
-      return canWrap(pm.doc, from, to, this, conf.attrs)
+      return canWrap(pm.doc, from, to, this)
     },
     params: deriveParams(this, conf.params)
   }

--- a/src/format/to_dom.js
+++ b/src/format/to_dom.js
@@ -14,7 +14,7 @@ class DOMSerializer {
     this.doc = this.options.document || window.document
   }
 
-  // :: (string, ?Object, ...union<string, DOMNode>) → DOMNode
+  // :: (string, ?Object, ...[union<string, DOMNode>]) → DOMNode
   // Create a DOM node of the given type, with (optionally) the given
   // attributes and content. Content elements may be strings (for text
   // nodes) or other DOM nodes.

--- a/src/test/build.js
+++ b/src/test/build.js
@@ -52,7 +52,7 @@ function flatten(children, f) {
 
 function id(x) { return x }
 
-// : (string, ?Object) → (...content: union<string, Node>) → Node
+// : (string, ?Object) → (...content: [union<string, Node>]) → Node
 // Create a builder function for nodes with content.
 function block(type, attrs) {
   return function() {

--- a/src/transform/ancestor.js
+++ b/src/transform/ancestor.js
@@ -161,11 +161,11 @@ Transform.prototype.lift = function(from, to = from, silent = false) {
   return this.step("ancestor", start, end, {depth: shared - depth})
 }
 
-// :: (Node, number, ?number, NodeType) → bool
+// :: (Node, number, number, NodeType) → bool
 // Determines whether the [sibling range](#Node.siblingRange) of the
 // given positions can be wrapped in the given node type.
 export function canWrap(doc, from, to, type) {
-  return !!checkWrap(doc.resolve(from), doc.resolve(to == null ? from : to), type)
+  return !!checkWrap(doc.resolve(from), doc.resolve(to), type)
 }
 
 function checkWrap($from, $to, type) {

--- a/src/transform/map.js
+++ b/src/transform/map.js
@@ -51,7 +51,7 @@ export class PosMap {
   // Create a position map. The modifications to the document are
   // represented as an array of numbers, in which each group of three
   // represents an [start, oldSize, newSize] chunk.
-  constructor(ranges, inverted) {
+  constructor(ranges, inverted = false) {
     this.ranges = ranges
     this.inverted = inverted || false
   }

--- a/src/ui/prompt.js
+++ b/src/ui/prompt.js
@@ -203,7 +203,7 @@ ParamPrompt.prototype.paramTypes.select = {
   }
 }
 
-// :: (ProseMirror, DOMNode, ?Object) → {close: ()}
+// :: (ProseMirror, DOMNode, ?{pos?: {left: number, top: number}, onClose?: ()}) → {close: ()}
 // Open a dialog box for the given editor, putting `content` inside of
 // it. The `close` method on the return value can be used to
 // explicitly close the dialog again. The following options are


### PR DESCRIPTION
As far as I see it, canWrap is never called with a falsy value as `to`.