### PR TITLE
Fix two bugs w.r.t drop target

### DIFF
--- a/src/edit/css.js
+++ b/src/edit/css.js
@@ -17,6 +17,7 @@ insertCSS(`
   position: absolute;
   width: 1px;
   background: #666;
+  z-index: -1;
 }
 
 .ProseMirror-content ul.tight p, .ProseMirror-content ol.tight p {

--- a/src/edit/input.js
+++ b/src/edit/input.js
@@ -500,7 +500,10 @@ handlers.dragstart = (pm, e) => {
   }
 }
 
-handlers.dragend = pm => window.setTimeout(() => pm.input.dragging = null, 50)
+handlers.dragend = pm => {
+  removeDropTarget(pm)
+  window.setTimeout(() => pm.input.dragging = null, 50)
+}
 
 handlers.dragover = handlers.dragenter = (pm, e) => {
   e.preventDefault()


### PR DESCRIPTION
Fixes a bug where the drag could end by a user hitting the escape
key resulting in the drop target persisting.

Fixes bug where a drag & drop would fail if the user happens to drop on
the 1px drop target element.