### PR TITLE
Add scrollThreshold and scrollMargin editor options

### DIFF
--- a/src/edit/dompos.js
+++ b/src/edit/dompos.js
@@ -135,22 +135,21 @@ function windowRect() {
           top: 0, bottom: window.innerHeight}
 }
 
-const scrollMargin = 5
-
 export function scrollIntoView(pm, pos) {
   if (!pos) pos = pm.sel.range.head || pm.sel.range.from
   let coords = coordsAtPos(pm, pos)
   for (let parent = pm.content;; parent = parent.parentNode) {
+    let {scrollThreshold, scrollMargin} = pm.options
     let atBody = parent == document.body
     let rect = atBody ? windowRect() : parent.getBoundingClientRect()
     let moveX = 0, moveY = 0
-    if (coords.top < rect.top)
+    if (coords.top < rect.top + scrollThreshold)
       moveY = -(rect.top - coords.top + scrollMargin)
-    else if (coords.bottom > rect.bottom)
+    else if (coords.bottom > rect.bottom - scrollThreshold)
       moveY = coords.bottom - rect.bottom + scrollMargin
-    if (coords.left < rect.left)
+    if (coords.left < rect.left + scrollThreshold)
       moveX = -(rect.left - coords.left + scrollMargin)
-    else if (coords.right > rect.right)
+    else if (coords.right > rect.right - scrollThreshold)
       moveX = coords.right - rect.right + scrollMargin
     if (moveX || moveY) {
       if (atBody) {

--- a/src/edit/options.js
+++ b/src/edit/options.js
@@ -61,6 +61,17 @@ defineOption("historyDepth", 100)
 // start a new history event. Defaults to 500.
 defineOption("historyEventDelay", 500)
 
+// :: number #path=scrollThreshold #kind=option
+// The minimum distance to keep between the position of document
+// changes and the editor bounding rectangle before scrolling the view.
+// Defaults to 0.
+defineOption("scrollThreshold", 0)
+
+// :: number #path=scrollMargin #kind=option
+// Determines how far to scroll when the scroll threshold is
+// surpassed. Defaults to 5.
+defineOption("scrollMargin", 5)
+
 // :: CommandSet #path=commands #kind=option
 // Specifies the set of [commands](#Command) available in the editor
 // (which in turn determines the base key bindings and items available


### PR DESCRIPTION
These options are useful if you want to keep a minimum distance between the actively edited position and the editor bounds. I found this to be especially useful when continuously writing at the bottom of the document. These options allow a custom behavior like this while the default values make it work exactly like it did before.