### PR TITLE
fix coordsAtPos at softlinebreak and after last character within block element, fixes #322

### DIFF
--- a/src/edit/dompos.js
+++ b/src/edit/dompos.js
@@ -86,7 +86,7 @@ export function DOMFromPos(pm, pos, loose) {
       if (size) {
         if (!offset) return {node: container, offset: i}
         size = +size
-        if (offset < size) {
+        if (offset <= size) {
           container = childContainer(child)
           if (!container) {
             return leafAt(child, offset)
@@ -226,7 +226,9 @@ function textRect(node, from, to) {
   let range = document.createRange()
   range.setEnd(node, to)
   range.setStart(node, from)
-  return range.getBoundingClientRect()
+  let rects = range.getClientRects()
+  // Return the last rect
+  return rects[rects.length-1]
 }
 
 function textRects(node) {

--- a/src/edit/dompos.js
+++ b/src/edit/dompos.js
@@ -70,7 +70,7 @@ export function childContainer(dom) {
 // : (ProseMirror, number) → {node: DOMNode, offset: number}
 // Find the DOM node and offset into that node that the given document
 // position refers to.
-export function DOMFromPos(pm, pos, loose) {
+export function DOMFromPos(pm, pos, loose, exactEndPos) {
   if (!loose && pm.operation && pm.doc != pm.operation.doc)
     throw new RangeError("Resolving a position in an outdated DOM structure")
 
@@ -86,7 +86,7 @@ export function DOMFromPos(pm, pos, loose) {
       if (size) {
         if (!offset) return {node: container, offset: i}
         size = +size
-        if (offset <= size) {
+        if (offset < size || (exactEndPos && offset === size)) {
           container = childContainer(child)
           if (!container) {
             return leafAt(child, offset)
@@ -242,7 +242,7 @@ function textRects(node) {
 // Given a position in the document model, get a bounding box of the character at
 // that position, relative to the window.
 export function coordsAtPos(pm, pos) {
-  let {node, offset} = DOMFromPos(pm, pos)
+  let {node, offset} = DOMFromPos(pm, pos, false, true)
   let side, rect
   if (node.nodeType == 3) {
     if (offset < node.nodeValue.length) {


### PR DESCRIPTION
Please review. It is not clear to me if the textRect function is ever called with arguments that will give no clientRects at all. In that case adjustments need to be made. 

This places the rect at the start of the line at softline breaks. This is almost a random choice as line-end may have been just as valid. However, when moving the caret through the text using the arrow keys on Chrome, line start is preferred over line end. So if the case is to communicate the visual placement of the caret, in most cases line start will be preferable.