### PR TITLE
Add execEvent option to MenuCommandSpec

### DIFF
--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -40,6 +40,7 @@ export class MenuCommand {
   constructor(command, options) {
     this.command_ = command
     this.options = options
+    this.options.execEvent = this.options.execEvent || "mousedown"
   }
 
   // :: (ProseMirror) → Command
@@ -83,7 +84,7 @@ export class MenuCommand {
     if (this.options.class) dom.classList.add(this.options.class)
     if (disabled) dom.classList.add(prefix + "-disabled")
     if (this.options.css) dom.style.cssText += this.options.css
-    dom.addEventListener("mousedown", e => {
+    dom.addEventListener(this.options.execEvent, e => {
       e.preventDefault(); e.stopPropagation()
       pm.signal("interaction")
       cmd.exec(pm, null, dom)
@@ -371,6 +372,10 @@ function separator() {
 // :: string #path=MenuCommandSpec.css
 // Optionally adds a string of inline CSS to the command's DOM
 // representation.
+
+// :: string #path=MenuCommandSpec.execEvent
+// Defines which event on the command's DOM representation should
+// trigger the execution of the command. Defaults to mousedown.
 
 // :: MenuCommandGroup
 // The inline command group.

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -40,7 +40,6 @@ export class MenuCommand {
   constructor(command, options) {
     this.command_ = command
     this.options = options
-    this.options.execEvent = this.options.execEvent || "mousedown"
   }
 
   // :: (ProseMirror) → Command
@@ -84,7 +83,7 @@ export class MenuCommand {
     if (this.options.class) dom.classList.add(this.options.class)
     if (disabled) dom.classList.add(prefix + "-disabled")
     if (this.options.css) dom.style.cssText += this.options.css
-    dom.addEventListener(this.options.execEvent, e => {
+    dom.addEventListener(this.options.execEvent || "mousedown", e => {
       e.preventDefault(); e.stopPropagation()
       pm.signal("interaction")
       cmd.exec(pm, null, dom)


### PR DESCRIPTION
I encountered a problem where I need the event, which triggers the execution of a command through a menu item, to be `click` instead of `mousedown`. This pull request enables this scenario without changing the default behavior.

A little more information about the problem I faced:
We have a menu item which should trigger a file upload and which needs to display a file picker dialog. We show a file picker by calling `click` on a hidden `input` element. This works fine in Chrome, but apparently Firefox silently ignores the `click` call on the `input`, when the user interaction, which triggered the function call, was a `mousedown`. Changing the event that is triggered by the user to `click` instead of `mousedown`, fixes the problem and shows a file picker in Firefox.