### PR TITLE
Add hardBreak option to MarkdownSerializer

### DIFF
--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -136,12 +136,13 @@ export class ProseMirror {
     this.setDoc(value)
   }
 
-  // :: (?string) → any
+  // :: (?string, ?object) → any
   // Get the editor's content in a given format. When `format` is not
   // given, a `Node` is returned. If it is given, it should be an
-  // existing [serialization format](#format).
-  getContent(format) {
-    return format ? serializeTo(this.doc, format) : this.doc
+  // existing [serialization format](#format). Options to the serializer
+  // may be given as a second argument.
+  getContent(format, options) {
+    return format ? serializeTo(this.doc, format, options || {}) : this.doc
   }
 
   setDocInner(doc) {

--- a/src/markdown/to_markdown.js
+++ b/src/markdown/to_markdown.js
@@ -32,8 +32,12 @@ class MarkdownSerializer {
     this.closed = false
     this.inTightList = false
     // :: Object
-    // The options passed to the serializer.
-    this.options = options
+    // The options passed to the serializer. The following are supported:
+    //
+    // **`hardBreak`**: ?string
+    //   : Markdown to use for hard line breaks. Defaults to a backslash
+    //     followed by a newline.
+    this.options = Object.assign({ hardBreak: "\\\n" }, options)
   }
 
   flushClose(size) {
@@ -277,7 +281,7 @@ def(Image, (state, node) => {
               (node.attrs.title ? " " + state.quote(node.attrs.title) : "") + ")")
 })
 
-def(HardBreak, state => state.write("\\\n"))
+def(HardBreak, state => state.write(state.options.hardBreak))
 
 def(Text, (state, node) => state.text(node.text))
 


### PR DESCRIPTION
This pull request adds an option to control which of the alternate [hard line break](http://spec.commonmark.org/0.24/#hard-line-breaks) markdown styles is used by `getContent("markdown")`.

To expose this feature, `getContent` accepts options to be passed through to the format serializer:

    text = editor.getContent("markdown", { hardBreak: "  \n" })

I wrote this for one of my projects in which I prefer the original hard break string. The `backslash newline` form is less commonly known than `space space newline`, and also seems less graceful under degradation or raw text conditions. A more technical concern is that it's not interoperable with ruby's [redcarpet](https://github.com/vmg/redcarpet) renderer, and perhaps others which parse the original markdown "spec" but not all CommonMark variants.

Feedback is welcome. And thanks for making ProseMirror!