### PR TITLE
Observe code block lang when parsing markdown

### DIFF
--- a/src/markdown/from_markdown.js
+++ b/src/markdown/from_markdown.js
@@ -253,7 +253,7 @@ function trimTrailingNewline(str) {
 }
 
 function parseCodeBlock(state, tok) {
-  state.openNode(this)
+  state.openNode(this, { params: /\S/.test(tok.info) ? tok.info : null });
   state.addText(trimTrailingNewline(tok.content))
   state.closeNode()
 }

--- a/src/model/defaultschema.js
+++ b/src/model/defaultschema.js
@@ -36,6 +36,7 @@ export class Heading extends Textblock {
 // allows unmarked text nodes inside of it.
 export class CodeBlock extends Textblock {
   get isCode() { return true }
+  get attrs() { return { params: new Attribute({default: null})} }
 }
 
 // ;; The default paragraph node type.


### PR DESCRIPTION
This branch sets the `params` attribute of `CodeBlock` when it's constructed from markdown. Since the `to_markdown` module creates a fenced codeblock when `attrs.params` is present, this preserves the original block's code language during `getContent`.

I see from #272 that this feature was forthcoming, so if there's something else in the works feel free to ignore.