### PR TITLE
Add MarkType for strikethrough, sub/superscript

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -155,6 +155,27 @@ export class CodeMark extends MarkType {
   toDOM() { return ["code"] }
 }
 
+// ;; The default strikethrough mark type.
+export class StrikeMark extends MarkType {
+  get matchDOMTag() { return {"s": null} }
+  get matchDOMStyle() {
+    return {"text-decoration": value => value == "line-through" && null}
+  }
+  toDOM() { return ["s"] }
+}
+
+// ;; The default subscript mark type.
+export class SubMark extends MarkType {
+  get matchDOMTag() { return {"sub": null} }
+  toDOM() { return ["sub"] }
+}
+
+// ;; The default superscript mark type.
+export class SupMark extends MarkType {
+  get matchDOMTag() { return {"sup": null} }
+  toDOM() { return ["sup"] }
+}
+
 // :: Schema
 // ProseMirror's default document schema.
 export const defaultSchema = new Schema({
@@ -180,6 +201,9 @@ export const defaultSchema = new Schema({
     em: EmMark,
     strong: StrongMark,
     link: LinkMark,
-    code: CodeMark
+    code: CodeMark,
+    strike: StrikeMark,
+    sub: SubMark,
+    sup: SupMark
   }
 })


### PR DESCRIPTION
Adds MarkType definitions for strikethrough, subscript and superscript inline formatting.

## Notes
* There doesn't seem to be any CommonMark syntax for any of these, so I wasn't able to add mappings to/from Markdown. GitHub has ~~strikethrough~~ using `~~` but that's not CommonMark.
* Strikethrough can be modeled either as `<s>` (pure formatting, no semantic meaning) or `<del>` (semantic meaning of document edit/removal). I picked the former because it's hard to infer whether the use is semantic or not, but it could easily be changed to the latter.
* I didn't register commands for these. It might make sense to add some though? Where are the current icons taken from? OTOH there doesn't seem to be standard keyboard shortcuts for any of them.