### PR TITLE
Add 'clean' user input to Field (and utilize for promptLinkAttrs)

### DIFF
--- a/src/schema/menu.js
+++ b/src/schema/menu.js
@@ -49,9 +49,18 @@ export const icons = {
 // the result.
 export function promptLinkAttrs(pm, callback) {
   new FieldPrompt(pm, "Create a link", {
-    href: new TextField({label: "Link target", required: true}),
+    href: new TextField({
+      label: "Link target",
+      required: true,
+      clean: (val) => {
+        if (!/^https?:\/\//i.test(val))
+          val = 'http://' + val
+        return val
+      }
+    }),
     title: new TextField({label: "Title"})
-  }).open(callback)
+  })
+    .open(callback)
 }
 
 // :: (ProseMirror, (attrs: ?Object))

--- a/src/ui/prompt.js
+++ b/src/ui/prompt.js
@@ -95,7 +95,7 @@ export class FieldPrompt {
         this.reportInvalid(dom, this.pm.translate(bad))
         return null
       }
-      result[name] = value
+      result[name] = field.clean(value)
     }
     return result
   }
@@ -153,6 +153,12 @@ export class Field {
     if (!value && this.options.required)
       return "Required field"
     return this.validateType(value) || (this.options.validate && this.options.validate(value))
+  }
+
+  // :: (any) → ?string
+  // Function to clean user input
+  clean(value) {
+    return this.options.clean ? this.options.clean(value) : value
   }
 }
 


### PR DESCRIPTION
 (currently used to ensure 'http://' exists in promptLinkAttrs)

This was slightly irking for me, since sometimes I manually type in a URL in the make link prompt, and then on clicking the link, it opens the wrong address, relative to the current page.

This commit includes 

1) The small addition of a 'clean' method which is a optionally set on the Fields within FieldPrompts 
2) A regular expression test for ensuring http:// exists in the user inputted href field.

No complaints after linting and running your test harness.  I didn't think it was necessary to write tests for this basic functionality but if you advise, then I can give that a shot.
