### PR TITLE
Support for Tab/Shift-Tab key to indent/de-indent lists

### DIFF
--- a/src/edit/commands.js
+++ b/src/edit/commands.js
@@ -603,14 +603,12 @@ exports.sinkListItem = sinkListItem
 function liftNested(nodeType) {
   let lift = liftListItem(nodeType)
   return function(pm, apply) {
-    let {head, empty} = pm.selection
+    let {$head, empty} = pm.selection
     if (!empty) return false
-
-    let $head = pm.doc.resolve(head)
     if ($head.parentOffset > 0) return false
 
-    let {from, to} = pm.selection, $from = pm.doc.resolve(from)
-    let depth = $from.blockRangeDepth(to, node => node.childCount && node.firstChild.type == nodeType)
+    let {$from, $to} = pm.selection
+    let depth = $from.depth
 
     // Skip if not a nested list
     if (depth == null || depth < 3) return false
@@ -626,10 +624,8 @@ exports.liftNested = liftNested
 function sinkNested(nodeType) {
   let sink = sinkListItem(nodeType)
   return function(pm, apply) {
-    let {head, empty} = pm.selection
+    let {$head, empty} = pm.selection
     if (!empty) return false
-
-    let $head = pm.doc.resolve(head)
     if ($head.parentOffset > 0) return false
 
     return sink(pm, apply)

--- a/src/schema/keymap.js
+++ b/src/schema/keymap.js
@@ -1,7 +1,7 @@
 const Keymap = require("browserkeymap")
 const {HardBreak, BulletList, OrderedList, ListItem, BlockQuote, HorizontalRule, Paragraph, CodeBlock, Heading, StrongMark, EmMark, CodeMark} = require("../schema")
 const browser = require("../util/browser")
-const {wrapIn, setBlockType, wrapInList, splitListItem, liftListItem, sinkListItem, chain, newlineInCode} = require("../edit/commands")
+const {wrapIn, setBlockType, wrapInList, splitListItem, liftListItem, sinkListItem, chain, newlineInCode, sinkNested, liftNested} = require("../edit/commands")
 const {Plugin} = require("../edit")
 
 // :: (Schema) → Keymap
@@ -50,6 +50,8 @@ function defaultSchemaKeymap(schema) {
     }
     if (node instanceof ListItem) {
       keys["Enter"] = splitListItem(node)
+      keys["Tab"] = sinkNested(node)
+      keys["Shift-Tab"] = liftNested(node)
       keys["Mod-["] = liftListItem(node)
       keys["Mod-]"] = sinkListItem(node)
     }

--- a/src/test/browser/test-keymaps.js
+++ b/src/test/browser/test-keymaps.js
@@ -139,3 +139,22 @@ test("Enter_lift",
 test("Enter_code_newline",
      doc(pre("foo<a>bar")),
      doc(pre("foo\nbar")))
+
+test("Tab_start_list_sink",
+     doc(ul(li(p("ab")), li(p("<a>cd")))),
+     doc(ul(li(p("ab"), ul(li(p("cd")))))))
+test("Tab_middle_list_noop",
+     doc(ul(li(p("ab")), li(p("cd<a>ef")))),
+     doc(ul(li(p("ab")), li(p("cdef")))))
+test("Tab_start_nested_list_noop",
+     doc(ul(li(p("ab"), ul(li(p("<a>cd")))))),
+     doc(ul(li(p("ab"), ul(li(p("cd")))))))
+test("Shift-Tab_start_list_lift",
+     doc(ul(li(p("ab"), ul(li(p("<a>cd")))))),
+     doc(ul(li(p("ab")), li(p("cd")))))
+test("Shift-Tab_middle_list_noop",
+     doc(ul(li(p("ab"), ul(li(p("cd<a>ef")))))),
+     doc(ul(li(p("ab"), ul(li(p("cdef")))))))
+test("Shift-Tab_start_flat_list_noop",
+     doc(ul(li(p("ab")), li(p("<a>cd")))),
+     doc(ul(li(p("ab")), li(p("cd")))))


### PR DESCRIPTION
Traditionally, rich text editors (Word, Google Docs, TinyMCE, etc) allow using Tab from the beginning of a list item to turn it into a nested list of the same kind, and Shift-Tab to de-indent (lift) a nested list up one level.

This PR adds support for this behaviour and some accompanying tests.