### PR TITLE
Added basic table support

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -10,6 +10,14 @@ textarea {
   padding: 4px 8px;
 }
 
+table {
+  border-collapse: collapse;
+}
+
+td, th {
+  border: 1px solid #000;
+}
+
 .left, .right {
   width: 50%;
   float: left;
@@ -41,4 +49,3 @@ textarea {
   padding: 4px 8px 4px 14px;
   line-height: 1.2;
 }
-

--- a/demo/index.html
+++ b/demo/index.html
@@ -94,6 +94,26 @@ yet.</p></blockquote></blockquote>
 Note that the content of a code block can't be styled.</code></pre>
 
 <p>This paragraph has<br>a hard break inside of it.</p>
+
+
+<table>
+  <caption>This is an example table</caption>
+  <tbody>
+    <tr>
+      <th>Column 1</th>
+      <th>Column 2</th>
+    </tr>
+    <tr>
+      <td><p>foo</p><ul><li>Item 1</li></li>Item 2</li></ul></td>
+      <td><p>bar</p></td>
+    </tr>
+    <tr>
+      <td><p>baz</p></td>
+      <td><p>qux</p></td>
+    </tr>
+  </tbody>
+</table>
+
 </div>
 
 <script src="/moduleserve/load.js" data-module="./demo" data-require></script>

--- a/src/edit/commands.js
+++ b/src/edit/commands.js
@@ -51,6 +51,10 @@ function joinBackward(pm, apply) {
 
   if ($head.parentOffset > 0) return false
 
+  let grandParent = $head.node($head.depth -1)
+  let isParentFirstChild = grandParent.child(0).eq($head.parent)
+  if (grandParent.type.isCell && isParentFirstChild) return false
+
   // Find the node before this one
   let before, cut
   for (let i = $head.depth - 1; !before && i >= 0; i--) if ($head.index(i) > 0) {
@@ -97,6 +101,10 @@ exports.joinBackward = joinBackward
 function joinForward(pm, apply) {
   let {$head, empty} = pm.selection
   if (!empty || $head.parentOffset < $head.parent.content.size) return false
+
+  let grandParent = $head.node($head.depth -1)
+  let isParentLastChild = grandParent.child(grandParent.childCount - 1).eq($head.parent)
+  if (grandParent.type.isCell && isParentLastChild) return false
 
   // Find the node after this one
   let after, cut
@@ -265,6 +273,10 @@ exports.createParagraphNear = createParagraphNear
 function liftEmptyBlock(pm, apply) {
   let {$head, empty} = pm.selection
   if (!empty || $head.parent.content.size) return false
+
+  let grandParent = $head.node($head.depth -1)
+  if (grandParent.type.isCell) return false
+
   if ($head.depth > 1 && $head.after() != $head.end(-1)) {
     let before = $head.before()
     if (canSplit(pm.doc, before)) {

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -170,6 +170,49 @@ class CodeMark extends MarkType {
 }
 exports.CodeMark = CodeMark
 
+// ;; The default table node type.
+class Table extends Block {
+  get matchDOMTag() { return {"table": null} }
+  toDOM() { return ["table", 0] }
+}
+exports.Table = Table
+
+// ;; The default caption node type.
+class Caption extends Block {
+  get matchDOMTag() { return {"caption": null} }
+  toDOM() { return ["caption", 0] }
+}
+exports.Caption = Caption
+
+// ;; The default table body node type.
+class TableBody extends Block {
+  get matchDOMTag() { return {"tbody": null} }
+  toDOM() { return ["tbody", 0] }
+}
+exports.TableBody = TableBody
+
+// ;; The default table row node type.
+class TableRow extends Block {
+  get matchDOMTag() { return {"tr": null} }
+  toDOM() { return ["tr", 0] }
+}
+exports.TableRow = TableRow
+
+// ;; The default table cell node type.
+class TableCell extends Block {
+  get isCell() { return true }
+  get matchDOMTag() { return {"td": null} }
+  toDOM() { return ["td", 0] }
+}
+exports.TableCell = TableCell
+
+// ;; The default table header cell node type.
+class TableHeaderCell extends TableCell {
+  get matchDOMTag() { return {"th": null} }
+  toDOM() { return ["th", 0] }
+}
+exports.TableHeaderCell = TableHeaderCell
+
 // :: Schema
 // ProseMirror's default document schema.
 const defaultSchema = new Schema({
@@ -188,7 +231,14 @@ const defaultSchema = new Schema({
 
     text: {type: Text, group: "inline"},
     image: {type: Image, group: "inline"},
-    hard_break: {type: HardBreak, group: "inline"}
+    hard_break: {type: HardBreak, group: "inline"},
+
+    table: {type: Table, content: "table_block+", group: "block"},
+    caption: {type: Caption, content: "text*", group: "table_block"},
+    tbody: {type: TableBody, content: "tr+", group: "table_block"},
+    tr: {type: TableRow, content: "cell+"},
+    td: {type: TableCell, content: "block+", group: "cell"},
+    th: {type: TableHeaderCell, content: "block+", group: "cell"}
   },
 
   marks: {

--- a/src/test/browser/test-command.js
+++ b/src/test/browser/test-command.js
@@ -1,7 +1,7 @@
 const {defTest} = require("../tests")
 const {tempEditor} = require("./def")
 const {cmpNode} = require("../cmp")
-const {doc, blockquote, pre, h1, h2, p, li, ol, ul, em, hr} = require("../build")
+const {doc, blockquote, pre, h1, h2, p, li, ol, ul, em, hr, table, tr, td} = require("../build")
 
 const {commands} = require("../../edit")
 const {defaultSchema: schema} = require("../../schema")
@@ -62,6 +62,12 @@ test("joinBackward",
 test("joinBackward",
      doc(p("<a>foo")),
      doc(p("foo")))
+test("joinBackward",
+     doc(p("hi"), table(tr(td(p("<a>there"))))),
+     doc(p("hi"), table(tr(td(p("there"))))))
+test("joinBackward",
+     doc(table(tr(td(p("there"), p("<a>foo"))))),
+     doc(table(tr(td(p("therefoo"))))))
 
 test("deleteSelection",
      doc(p("f<a>o<b>o")),
@@ -132,6 +138,12 @@ test("joinForward",
 test("joinForward",
      doc(blockquote(p("there<a>")), hr),
      doc(blockquote(p("there"))))
+test("joinForward",
+     doc(p("hi"), table(tr(td(p("there<a>"))))),
+     doc(p("hi"), table(tr(td(p("there"))))))
+test("joinForward",
+     doc(table(tr(td(p("there<a>"), p("foo"))))),
+     doc(table(tr(td(p("therefoo"))))))
 
 test("deleteCharAfter",
      doc(p("b<a>ar")),
@@ -340,6 +352,9 @@ test("liftEmptyBlock",
 test("liftEmptyBlock",
      doc(ul(li(p("hi")), li(p("<a>")))),
      doc(ul(li(p("hi"))), p()))
+test("liftEmptyBlock",
+     doc(table(tr(td(p("<a>"))))),
+     doc(table(tr(td(p())))))
 
 test("createParagraphNear",
      doc("<a>", hr),

--- a/src/test/build.js
+++ b/src/test/build.js
@@ -94,6 +94,12 @@ const ul = block("bullet_list")
 exports.ul = ul
 const ol = block("ordered_list")
 exports.ol = ol
+const table = block("table")
+exports.table = table
+const tr = block("tr")
+exports.tr = tr
+const td = block("td")
+exports.td = td
 
 const br = schema.node("hard_break")
 exports.br = br


### PR DESCRIPTION
Goal of this PR is to introduce basic table handling support in ProseMirror. Use cases for this are authoring existing documents containing tables and pasting contents that contains tables.

Providing commands and menu items to insert / delete tables, insert / delete rows or columns are **non-goals** of this PR.