### PR TITLE
Fix Node#textContent to return a value

### DIFF
--- a/src/model/node.js
+++ b/src/model/node.js
@@ -71,7 +71,7 @@ class Node {
   // :: string
   // Concatenates all the text nodes found in this fragment and its
   // children.
-  get textContent() { this.textBetween(0, this.content.size, "") }
+  get textContent() { return this.textBetween(0, this.content.size, "") }
 
   // :: (number, number, ?string) → string
   // Get all text between positions `from` and `to`. When `separator`

--- a/src/test/test-node.js
+++ b/src/test/test-node.js
@@ -78,6 +78,20 @@ between("inline",
         doc(p(em("x"), "f<a>oo", em("bar", img, strong("baz"), br), "quux", code("xy<b>z"))),
         "paragraph", "foo", "bar", "image", "baz", "hard_break", "quux", "xyz")
 
+function textContent(name, node, expect) {
+  defTest("node_textContent_" + name, () => {
+    cmpStr(node.textContent, expect)
+  })
+}
+
+textContent("doc",
+            doc(p("foo")),
+            "foo")
+
+textContent("text",
+            schema.text("foo"),
+            "foo")
+
 function from(name, arg, expect) {
   defTest("node_fragment_from_" + name, () => {
     cmpNode(expect.copy(Fragment.from(arg)), expect)


### PR DESCRIPTION
This was a regression in 0.8.x from 0.7.0.

Simple code to replicate:

``` js
// Given `schema` the default Schema in schema-basic
var doc = schema.node('doc', {}, [schema.node('paragraph', {}, [schema.text('hello')])]);
doc.textContent; // undefined (expected 'hello')
doc.firstChild.textContent // undefined (expected 'hello')
doc.firstChild.firstChild.textContent // 'hello'
```

I've also added simple tests to demonstrate.