### PR TITLE
Change baseKeymap to be mutable to prevent error on Mac

### DIFF
--- a/src/edit/keymap.js
+++ b/src/edit/keymap.js
@@ -20,7 +20,7 @@ const c = require("./commands").commands
 // * **Esc** to `selectParentNode`
 // * **Mod-Z** to `undo`
 // * **Mod-Y** and **Shift-Mod-Z** to `redo`
-const baseKeymap = new Keymap({
+var baseKeymap = new Keymap({
   "Enter": c.chainCommands(c.newlineInCode, c.createParagraphNear,
                            c.liftEmptyBlock, c.splitBlock),
 


### PR DESCRIPTION
Fixes an issue with mutating a `const` (if `browser.mac` is `true`) introduced by https://github.com/ProseMirror/prosemirror/commit/1d450404f0be3fed39134ea719204f4bafbafa51

Alternatively could use an extra variable to keep everything `const` and avoid mutations.