### PR TITLE
Mention tests require Node 6+ in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,8 @@ Before reporting a bug, read these pointers.
   the `test/` directory. Either put them in an existing `test-*.js`
   file, if they fit there, or add a new file.
 
-- Make sure all tests pass. Run `npm run test` verify tests pass.
-  Also run browser tests by starting the demo (`npm run demo`) and
+- Make sure all tests pass. Run `npm run test` verify tests pass (you will need
+  Node.js v6+). Also run browser tests by starting the demo (`npm run demo`) and
   visiting [http://localhost:8080/test.html](http://localhost:8080/test.html)
   in a browser.
 


### PR DESCRIPTION
I can see `package.json` was [changed](https://github.com/ProseMirror/prosemirror/commit/f75b6adec4f427c2aa916e767fb363bfcc640887) to run tests from `src`, however this doesn't work for me:

```
$ npm run test

> prosemirror@0.8.1 test .../prosemirror
> node src/test/run.js

.../prosemirror/src/test/run.js:1
(function (exports, require, module, __filename, __dirname) { const {Failure} = require("./failure")
                                                                    ^

SyntaxError: Unexpected token {
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:387:25)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Function.Module.runMain (module.js:447:10)
    at startup (node.js:146:18)
    at node.js:404:3
```

Changing the test to run against `dist` fixes it for me. Is there a way to make the current setup run against `src`?