### PR TITLE
Support markdown parsing and serializing of indented code block

### DIFF
--- a/src/markdown/from_markdown.js
+++ b/src/markdown/from_markdown.js
@@ -91,6 +91,15 @@ function tokenHandlers(schema, tokens) {
     let spec = tokens[type]
     if (spec.block) {
       let nodeType = schema.nodeType(spec.block)
+
+      if (type == "code_block") { // code_block defined by alignment
+        handlers[type] = (state, tok) => {
+          state.openNode(nodeType, attrs(spec.attrs, tok))
+          state.addText(tok.content)
+          state.closeNode()
+        }
+      }
+
       handlers[type + "_open"] = (state, tok) => state.openNode(nodeType, attrs(spec.attrs, tok))
       handlers[type + "_close"] = state => state.closeNode()
     } else if (spec.node) {

--- a/src/markdown/to_markdown.js
+++ b/src/markdown/to_markdown.js
@@ -44,7 +44,8 @@ const defaultMarkdownSerializer = new MarkdownSerializer({
   },
   code_block(state, node) {
     if (node.attrs.params == null) {
-      state.wrapBlock("    ", null, node, () => state.text(node.textContent, false))
+      let textContent = node.textContent || node.content.firstChild.text
+      state.wrapBlock("    ", null, node, () => state.text(textContent, false))
     } else {
       state.write("```" + node.attrs.params + "\n")
       state.text(node.textContent, false)


### PR DESCRIPTION
To reproduce, try parsing following markdown with default parser:

```
Code

    Block
```

I'm not sure my fix for serializer is correct, please let me know if there's a better way.