### PR TITLE
Fix menu icons visibility with pjax navigation

### DIFF
--- a/src/menu/icons.js
+++ b/src/menu/icons.js
@@ -1,12 +1,31 @@
 const {insertCSS} = require("../util/dom")
 
-let svgCollection = null
-const svgBuilt = Object.create(null)
-
 const SVG = "http://www.w3.org/2000/svg"
 const XLINK = "http://www.w3.org/1999/xlink"
 
-const prefix = "ProseMirror-icon"
+var prefix = "ProseMirror-icon"
+
+let svgCollectionContainer = null
+var svgCollectionContainerId = prefix + "-collection-container"
+
+function nodeById(id) {
+  return document.getElementById(id)
+}
+
+function nodeExists(id) {
+  return nodeById(id) != null
+}
+
+function svgContainer() {
+  if (!nodeExists(svgCollectionContainerId) || svgCollectionContainer != nodeById(svgCollectionContainerId)) {
+    svgCollectionContainer = document.createElementNS(SVG, "svg")
+    svgCollectionContainer.style.display = "none"
+    svgCollectionContainer.id = svgCollectionContainerId
+    document.body.insertBefore(svgCollectionContainer, document.body.firstChild)
+  }
+
+  return svgCollectionContainer
+}
 
 function hashPath(path) {
   let hash = 0
@@ -20,7 +39,7 @@ function getIcon(icon) {
   node.className = prefix
   if (icon.path) {
     let name = "pm-icon-" + hashPath(icon.path).toString(16)
-    if (!svgBuilt[name]) buildSVG(name, icon)
+    if (!nodeExists(name)) buildSVG(name, icon)
     let svg = node.appendChild(document.createElementNS(SVG, "svg"))
     svg.style.width = (icon.width / icon.height) + "em"
     let use = svg.appendChild(document.createElementNS(SVG, "use"))
@@ -36,18 +55,12 @@ function getIcon(icon) {
 exports.getIcon = getIcon
 
 function buildSVG(name, data) {
-  if (!svgCollection) {
-    svgCollection = document.createElementNS(SVG, "svg")
-    svgCollection.style.display = "none"
-    document.body.insertBefore(svgCollection, document.body.firstChild)
-  }
   let sym = document.createElementNS(SVG, "symbol")
   sym.id = name
   sym.setAttribute("viewBox", "0 0 " + data.width + " " + data.height)
   let path = sym.appendChild(document.createElementNS(SVG, "path"))
   path.setAttribute("d", data.path)
-  svgCollection.appendChild(sym)
-  svgBuilt[name] = true
+  svgContainer().appendChild(sym)
 }
 
 insertCSS(`


### PR DESCRIPTION
Pjax navigation allow to navigate without full page reload
by replacing page elements, usually the body, with dynamically
loaded content.
Prosemirror uses module constants to cache the SVG icons container
and to check if each icon has been already loaded or not.
This behaviour breaks when the pjax driver deletes the body and replaces
it with the new content: the cache objects are still set but the
SVG icons are not there anymore, hence they disappear from the menubar.