### PR TITLE
Use `ownerDocument` to be able to work under shadow dom

### DIFF
--- a/src/edit/dompos.js
+++ b/src/edit/dompos.js
@@ -169,7 +169,7 @@ function scrollIntoView(pm, pos) {
   let coords = coordsAtPos(pm, pos)
   for (let parent = pm.content;; parent = parent.parentNode) {
     let {scrollThreshold, scrollMargin} = pm.options
-    let atBody = parent == document.body
+    let atBody = parent == pm.content.ownDocument.body
     let rect = atBody ? windowRect() : parent.getBoundingClientRect()
     let moveX = 0, moveY = 0
     if (coords.top < rect.top + scrollThreshold)

--- a/src/edit/dompos.js
+++ b/src/edit/dompos.js
@@ -169,7 +169,7 @@ function scrollIntoView(pm, pos) {
   let coords = coordsAtPos(pm, pos)
   for (let parent = pm.content;; parent = parent.parentNode) {
     let {scrollThreshold, scrollMargin} = pm.options
-    let atBody = parent == pm.content.ownDocument.body
+    let atBody = parent == pm.content.ownerDocument.body
     let rect = atBody ? windowRect() : parent.getBoundingClientRect()
     let moveX = 0, moveY = 0
     if (coords.top < rect.top + scrollThreshold)

--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -472,7 +472,7 @@ class ProseMirror {
   // Query whether the editor has focus.
   hasFocus() {
     if (this.sel.range instanceof NodeSelection)
-      return this.content.ownDocument.activeElement == this.content
+      return this.content.ownerDocument.activeElement == this.content
     else
       return hasFocus(this)
   }

--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -472,7 +472,7 @@ class ProseMirror {
   // Query whether the editor has focus.
   hasFocus() {
     if (this.sel.range instanceof NodeSelection)
-      return document.activeElement == this.content
+      return this.content.ownDocument.activeElement == this.content
     else
       return hasFocus(this)
   }

--- a/src/edit/selection.js
+++ b/src/edit/selection.js
@@ -381,7 +381,7 @@ function selectionFromDOM(doc, oldHead) {
 }
 
 function hasFocus(pm) {
-  if (document.activeElement != pm.content) return false
+  if (pm.content.ownDocument.activeElement != pm.content) return false
   let sel = window.getSelection()
   return sel.rangeCount && contains(pm.content, sel.anchorNode)
 }

--- a/src/edit/selection.js
+++ b/src/edit/selection.js
@@ -381,7 +381,7 @@ function selectionFromDOM(doc, oldHead) {
 }
 
 function hasFocus(pm) {
-  if (pm.content.ownDocument.activeElement != pm.content) return false
+  if (pm.content.ownerDocument.activeElement != pm.content) return false
   let sel = window.getSelection()
   return sel.rangeCount && contains(pm.content, sel.anchorNode)
 }


### PR DESCRIPTION
ProseMirror does not support being used inside a Shadow DOM.
The problem lays in this code which guards editor input.
`document.activeElement` does not pierce Shadow DOM boundaries. It looks like `element.ownerDocument` should be used instead of `document`.