### PR TITLE
fix normalizeList

### DIFF
--- a/src/model/from_dom.js
+++ b/src/model/from_dom.js
@@ -415,6 +415,7 @@ class DOMParseState {
       if (child.nodeType == 1 &&
           listTags.hasOwnProperty(child.nodeName.toLowerCase()) &&
           (prev = child.previousSibling)) {
+        while (prev.nodeType != 1) prev = prev.previousSibling;
         prev.appendChild(child)
         child = prev
       }


### PR DESCRIPTION
if previousSibling is a text node it will throw an error just like
> Failed to execute 'appendChild' on 'Node': This node type does not support this method. 