### PR TITLE
make prosemirror work in shadow dom

### DIFF
--- a/src/edit/domchange.js
+++ b/src/edit/domchange.js
@@ -35,7 +35,7 @@ function parseBetween(pm, from, to) {
     if (next.nodeType != 1 || !next.hasAttribute("pm-offset")) ++endOff
     else break
   }
-  let domSel = window.getSelection(), find = null
+  let domSel = pm.root.getSelection(), find = null
   if (domSel.anchorNode && pm.content.contains(domSel.anchorNode)) {
     find = [{node: domSel.anchorNode, offset: domSel.anchorOffset}]
     if (!domSel.isCollapsed)

--- a/src/edit/dompos.js
+++ b/src/edit/dompos.js
@@ -258,7 +258,7 @@ function targetKludge(dom, coords) {
 
 // Given an x,y position on the editor, get the position in the document.
 function posAtCoords(pm, coords) {
-  let elt = targetKludge(document.elementFromPoint(coords.left, coords.top + 1), coords)
+  let elt = targetKludge(pm.root.elementFromPoint(coords.left, coords.top + 1), coords)
   if (!contains(pm.content, elt)) return null
 
   let {node, offset} = findOffsetInNode(elt, coords), bias = -1

--- a/src/edit/input.js
+++ b/src/edit/input.js
@@ -236,7 +236,7 @@ class MouseDown {
     this.target = event.target
     if (this.mightDrag) {
       if (!contains(pm.content, this.target))
-        this.target = document.elementFromPoint(this.x, this.y)
+        this.target = pm.root.elementFromPoint(this.x, this.y)
       this.target.draggable = true
       if (browser.gecko && (this.setContentEditable = !this.target.hasAttribute("contentEditable")))
         this.target.setAttribute("contentEditable", "false")

--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -186,6 +186,9 @@ class ProseMirror {
     this.options.keymaps.forEach(map => this.addKeymap(map, -100))
 
     this.options.plugins.forEach(plugin => plugin.attach(this))
+
+    // get the root of prosemirror since it could be in a shadow dom
+    this.root = (opts.place && opts.place.host) || document
   }
 
   // :: (string) → any
@@ -472,7 +475,7 @@ class ProseMirror {
   // Query whether the editor has focus.
   hasFocus() {
     if (this.sel.range instanceof NodeSelection)
-      return this.content.ownerDocument.activeElement == this.content
+      return this.pm.root.activeElement == this.content
     else
       return hasFocus(this)
   }

--- a/src/edit/selection.js
+++ b/src/edit/selection.js
@@ -65,14 +65,14 @@ class SelectionState {
   // : () → bool
   // Whether the DOM selection has changed from the last known state.
   domChanged() {
-    let sel = window.getSelection()
+    let sel = this.pm.root.getSelection()
     return sel.anchorNode != this.lastAnchorNode || sel.anchorOffset != this.lastAnchorOffset ||
       sel.focusNode != this.lastHeadNode || sel.focusOffset != this.lastHeadOffset
   }
 
   // Store the current state of the DOM selection.
   storeDOMState() {
-    let sel = window.getSelection()
+    let sel = this.pm.root.getSelection()
     this.lastAnchorNode = sel.anchorNode; this.lastAnchorOffset = sel.anchorOffset
     this.lastHeadNode = sel.focusNode; this.lastHeadOffset = sel.focusOffset
   }
@@ -116,7 +116,7 @@ class SelectionState {
       this.pm.content.classList.add("ProseMirror-nodeselection")
       this.lastNode = dom
     }
-    let range = document.createRange(), sel = window.getSelection()
+    let range = document.createRange(), sel = this.pm.getSelection()
     range.selectNode(dom)
     sel.removeAllRanges()
     sel.addRange(range)
@@ -130,7 +130,7 @@ class SelectionState {
     let anchor = DOMFromPos(this.pm, this.range.anchor)
     let head = DOMFromPos(this.pm, this.range.head)
 
-    let sel = window.getSelection(), range = document.createRange()
+    let sel = this.pm.getSelection(), range = document.createRange()
     if (sel.extend) {
       range.setEnd(anchor.node, anchor.offset)
       range.collapse(false)
@@ -356,7 +356,7 @@ class SelectionToken {
 }
 
 function selectionFromDOM(doc, oldHead) {
-  let sel = window.getSelection()
+  let sel = this.pm.getSelection()
   let {pos: head, inLeaf: headLeaf} = posFromDOM(sel.focusNode, sel.focusOffset)
   if (headLeaf > -1 && sel.isCollapsed) {
     let $leaf = doc.resolve(headLeaf), node = $leaf.nodeAfter
@@ -381,8 +381,8 @@ function selectionFromDOM(doc, oldHead) {
 }
 
 function hasFocus(pm) {
-  if (pm.content.ownerDocument.activeElement != pm.content) return false
-  let sel = window.getSelection()
+  if (pm.root.activeElement != pm.content) return false
+  let sel = this.pm.getSelection()
   return sel.rangeCount && contains(pm.content, sel.anchorNode)
 }
 exports.hasFocus = hasFocus

--- a/src/menu/tooltipmenu.js
+++ b/src/menu/tooltipmenu.js
@@ -115,7 +115,7 @@ class TooltipMenu {
 
 // Get the x and y coordinates at the top center of the current DOM selection.
 function topCenterOfSelection() {
-  let range = window.getSelection().getRangeAt(0), rects = range.getClientRects()
+  let range = this.pm.root.getSelection().getRangeAt(0), rects = range.getClientRects()
   if (!rects.length) return range.getBoundingClientRect()
   let left, right, top, bottom
   for (let i = 0; i < rects.length; i++) {
@@ -134,7 +134,7 @@ function topCenterOfSelection() {
 }
 
 function bottomCenterOfSelection() {
-  let range = window.getSelection().getRangeAt(0), rects = range.getClientRects()
+  let range = this.pm.root.getSelection().getRangeAt(0), rects = range.getClientRects()
   if (!rects.length) {
     let rect = range.getBoundingClientRect()
     return {left: rect.left, top: rect.bottom}


### PR DESCRIPTION
shadowRoot is a DOM Node and it is the standard (https://twitter.com/MaoStevemao/status/767864034049732608). We keep a reference of `root` in prosemirror instance.

I tried to do a global search in src and compare `document`/`window` with https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot, to see if we could use `pm.root` DOM Node instead. There might be something missing either in the MDN docs or in the source code.