### PR TITLE
Fix splitListItem to work with any list_item content schema

### DIFF
--- a/src/commands-list/index.js
+++ b/src/commands-list/index.js
@@ -63,7 +63,7 @@ function splitListItem(nodeType) {
         $from.depth < 2 || !$from.sameParent($to)) return false
     let grandParent = $from.node(-1)
     if (grandParent.type != nodeType) return false
-    let nextType = $to.pos == $from.end() ? grandParent.defaultContentType($from.indexAfter(-1)) : null
+    let nextType = $to.pos == $from.end() ? grandParent.defaultContentType(0) : null
     let tr = pm.tr.delete($from.pos, $to.pos)
     if (!canSplit(tr.doc, $from.pos, 2, nextType)) return false
     tr.split($from.pos, 2, nextType).applyAndScroll()


### PR DESCRIPTION
This minor change makes no difference for the schema-basic, but fixes the `Cannot join paragraph onto ordered_list` error thrown upon trying to split a `list_item` with a custom schema with a more constrained `list_item` content definition, such as `"paragraph (ordered_list | bullet_list)?"`.

The changed `splitListItem` picks `nextType` as the default type allowed as initial node in a `list_item`, since we're about to split the content and put the rest in a new `list_item`.

Currently, `splitListItem` chooses `nextType` based on what type would be next *if no split happened* (i.e. the next type that should appear next in the `list_item` according to the content definition). In the default schema (where `list_item` contains `"paragraph block*"`), that successor type is `block*`, the default of which resolves to `paragraph`, which happens to also be the type expected at the beginning of a `list_item`. This proves that the change should be a noop for the default schema.

See [this comment](https://github.com/ProseMirror/prosemirror/issues/443#issuecomment-243489715) on the original issue (https://github.com/ProseMirror/prosemirror/issues/443) for full context.

Fixes https://github.com/ProseMirror/prosemirror/issues/443