### PR TITLE
Fix flush() not working on IE11.

### DIFF
--- a/src/edit/main.js
+++ b/src/edit/main.js
@@ -360,7 +360,10 @@ class ProseMirror {
   flush() {
     this.unscheduleFlush()
 
-    if (!this.root.contains(this.wrapper) || !this.operation) return false
+    // IE11 supports `contains` only on elements.
+    // if Document node is set as the root, return its root element
+    var rootElement = this.root.nodeType === 9 ? this.root.documentElement : this.root;
+    if (!rootElement.contains(this.wrapper) || !this.operation) return false
     this.on.flushing.dispatch()
 
     let op = this.operation, redrawn = false


### PR DESCRIPTION
ProseMirror 0.10.0 doesn't work on IE11 due to this bug.