### PR TITLE
Provide demo boilerplate link in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,20 +1,30 @@
 ### Issue details
 
-_Please provide issue details here_.
+<!-- Please provide issue details here. -->
 
 ### Steps to reproduce
 
-_Please provide necessary steps for reproduction of this issue._
+<!--
+Please provide necessary steps for reproduction of this issue. To minimally reproduces the issue, you can use this Glitch demo to start with.
 
-### Please specify which version of ProseMirror you're running
+https://glitch.com/edit/#!/remix/prosemirror-demo-basic
+-->
 
-ProseMirror v[    ]
+### ProseMirror version
+
+<!-- Please provide which version of ProsemMirror you're running. -->
 
 ### Affected platforms
 
-- [ ] Chrome _(please specify version)_
-- [ ] Firefox _(please specify version)_
-- [ ] Internet Explore _(please specify version)_
-- [ ] Other _(please specify which)_
+<!-- Please provide specific version of affected browsers or platforms. -->
+
+- [ ] Chrome
+- [ ] Firefox
+- [ ] Internet Explorer
+- [ ] Other
 
 ### Screenshots / Screencast (Optional)
+
+<!--
+For convenience, you can use [Recordit](http://recordit.co/) to share screencast GIF.
+-->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,7 +5,7 @@
 ### Steps to reproduce
 
 <!--
-Please provide necessary steps for reproduction of this issue. To minimally reproduces the issue, you can use this Glitch demo to start with.
+Please provide necessary steps to reproduce the issue. For convenience, you can use this Glitch demo to start with.
 
 https://glitch.com/edit/#!/remix/prosemirror-demo-basic
 -->


### PR DESCRIPTION
Hi, I've been using ProseMirror for some time and I'm ready to report some issues and patches.

One minor problem I encountered during this process is that I haven't found a recommended way, say, JSFiddle, to provide a "live" issue reproduction. Eventually I recall the Glitch [demo](https://glitch.com/edit/#!/remix/prosemirror-demo-basic) in ProseMirror's [basic example page](http://prosemirror.net/examples/basic/) that helps, while for current issues, seems that such tool is not widely utilized.

Previously when contributing to Slate.js, I found its [issue template](https://github.com/ianstormtaylor/slate/blob/master/.github/ISSUE_TEMPLATE.md) provides some friendly links for reproducing issues and screencasts, so this PR simply introduces them, with slight improvement in template formatting. With these guides written in `<!--  -->` comments, issues can have a neat layout by default, without the need for reporters to manually removing them.