### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM debian:bullseye-20210721-slim@sha256:9bfa0f4fb6d32116de4a6172f89a9266f7c73d1b8dae46f765bed703e541175e
+
+ENV LANG     C.UTF-8
+ENV LC_ALL   C.UTF-8
+ENV LANGUAGE C.UTF-8
+
+# System deps
+RUN apt-get update -y && apt-get install curl gnupg -y && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update -y && \
+    apt-get install -y nodejs yarn git npm
+
+# Files
+COPY . /workdir
+WORKDIR /workdir
+
+# Install everything
+RUN bin/pm install


### PR DESCRIPTION
Background:

* I actively don't use node, yarn, npm, flatpack, rollup, tree-shaker-du-jour etc. 
* I'm an old-school JS dev that just wants a nice single `.js` file that puts a `ProseMirror` object in my global scope without any of the CommonJS/es6/requirejs/whatever import gubbins. 
*  I like to just follow the ProseMirror manual and use the API, without being dragged into another build system.

My solution:

* Here's a `Dockerfile` that will wrap up all the build system thingies and generates the .js files.
* You can run the demo server via: `docker run --net=host --rm chrisdone/prosemirror sh -c 'cd demo; npm run demo'` I've confirmed it works fine.
* The nice thing is that I'll be able to pin ProseMirror to a precise Git commit.

**Question:** how might I go about producing said plain .js file with `PM` (or whatever) in the global scope? Presently, I have a bunch of the directories with the index.js and such inside.

Whatever it is I'll add it to the `Dockerfile` and be on my merry way!

---

Feel free to close this PR if you're not interested in a Dockerfile, however if someone is googling how to build ProseMirror without installing a bunch of paraphernalia in their main system, they might find this useful.