### PR TITLE
Fix install error on Windows

### DIFF
--- a/bin/pm.js
+++ b/bin/pm.js
@@ -126,7 +126,8 @@ function install(arg = null) {
   })
 
   console.log("Running npm install")
-  run("npm", ["install"])
+  let npm = process.platform == 'win32' ? 'npm.cmd' : 'npm'
+  run(npm, ["install"])
   console.log("Building modules")
   build()
 }


### PR DESCRIPTION
### I referenced this [Link](https://stackoverflow.com/a/37138541)

- **Tools**: Windows, Visual Studio Code, Npm v8.15.0, Node v16.17.0

- **Problem**: `bin/pm install` command fails with following error

![image](https://user-images.githubusercontent.com/81248624/232214528-25b34bbe-7cb8-45ae-96d4-50e3daf82601.png)

- **Steps to reproduce**:
Open the project in Visual Studio code.
Enter `node .\bin\pm.js install`.
